### PR TITLE
Fix: Switch from pytest-cov to coverage.py for accurate plugin coverage tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication with Codecov
     strategy:
       fail-fast: false
       matrix:
@@ -33,14 +35,22 @@ jobs:
 
     - name: Run tests with coverage
       run: |
-        poetry run pytest --cov=src --cov-report=xml --cov-report=term-missing
+        poetry run coverage run -m pytest
+
+    - name: Generate coverage reports
+      run: |
+        poetry run coverage xml
+        poetry run coverage report --show-missing
+      if: matrix.python-version == '3.12'
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        use_oidc: true  # Use OIDC authentication instead of token
+        files: ./coverage.xml
+        flags: python-${{ matrix.python-version }}
+        name: pytest-test-categories
         fail_ci_if_error: false
-        token: ${{ secrets.CODECOV_TOKEN }}
       if: matrix.python-version == '3.12'
 
     - name: Check coverage meets target

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,18 +30,10 @@ repos:
         types: [python]
         pass_filenames: false
 
-      - id: pytest
-        name: pytest
-        entry: poetry run pytest
+      - id: pytest-coverage
+        name: pytest with coverage
+        entry: bash -c 'poetry run coverage run -m pytest && poetry run coverage report && poetry run python tests/_utils/check_coverage.py'
         language: system
         types: [python]
         pass_filenames: false
         always_run: true
-
-#      - id: pytest-with-coverage
-#        name: pytest with coverage check
-#        entry: bash -c 'COVERAGE_REPORT=term-missing poetry run pytest && poetry run python tests/_utils/check_coverage.py'
-#        language: system
-#        types: [python]
-#        pass_filenames: false
-#        always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,24 +55,36 @@ poetry run pre-commit run --all-files
 ```
 
 ### Testing Commands
+
+**Coverage Note**: This project uses `coverage run` instead of `pytest --cov` because pytest loads plugins before coverage tracking starts. Using `coverage run -m pytest` ensures all module-level code (imports, class definitions, decorators) is tracked correctly.
+
 ```bash
 # Run all tests with coverage
-poetry run pytest
+poetry run coverage run -m pytest
 
-# Run a single test file
+# View coverage report in terminal
+poetry run coverage report
+
+# View detailed coverage with missing lines
+poetry run coverage report --show-missing
+
+# Generate XML coverage report (for codecov)
+poetry run coverage xml
+
+# Generate HTML coverage report for local viewing
+poetry run coverage html
+
+# Run a single test file (without coverage)
 poetry run pytest tests/test_plugin_module.py
 
-# Run a single test function
+# Run a single test function (without coverage)
 poetry run pytest tests/test_plugin_module.py::test_function_name
 
-# Run a specific test class
+# Run a specific test class (without coverage)
 poetry run pytest tests/test_plugin_module.py::DescribeClass
 
-# Run tests with detailed output
+# Run tests with detailed output (without coverage)
 poetry run pytest -vv
-
-# Run tests with coverage report in terminal
-COVERAGE_REPORT=term-missing poetry run pytest
 ```
 
 ### Code Quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ testpaths = ["tests"]
 python_files = ["it_*.py", "test_*.py"]
 python_functions = ["it_*"]
 python_classes = ["Describe[A-Z]*"]
-addopts = ["-s", "-ra", "-q", "-vv", "--cov=src", "--cov-config=pyproject.toml"]
+addopts = ["-s", "-ra", "-q", "-vv"]
 pythonpath = ["src", "tests/plugins"]
 
 filterwarnings = [


### PR DESCRIPTION
## Problem

After merging PR #16, we discovered that pytest-cov was showing only 28% coverage for `types.py` despite comprehensive tests exercising all the code. This occurred because **pytest loads plugins BEFORE coverage tracking starts**.

## Root Cause

As a pytest plugin (registered via `[project.entry-points.pytest11]`), this package's modules are imported during pytest startup, before pytest-cov starts coverage tracking. This means all module-level code executes unmeasured:

```python
! from __future__ import annotations  # NOT tracked
! class TestSize(StrEnum):            # NOT tracked  
!     SMALL = 'small'                 # NOT tracked
>         return self.name.lower()    # Tracked (runtime code)
```

This is a **fundamental limitation of pytest-cov when testing pytest plugins**.

## Solution

Switched from `pytest --cov` to `coverage run -m pytest` which starts coverage tracking **before** pytest initialization, ensuring all code is measured correctly.

## Changes

### Configuration Updates
- **pyproject.toml**: Removed `--cov=src` and `--cov-config=pyproject.toml` from pytest addopts
- **CLAUDE.md**: 
  - Updated all testing commands to use `coverage run -m pytest`
  - Added explanation of why we use coverage.py for plugin testing
  - Documented commands for XML/HTML report generation
  
### CI/CD Improvements
- **GitHub CI workflow** (`.github/workflows/ci.yml`):
  - ✅ Added `permissions: id-token: write` for codecov OIDC authentication
  - ✅ Changed from `pytest --cov` to `coverage run -m pytest`
  - ✅ Added separate coverage report generation step
  - ✅ Updated codecov action with `use_oidc: true` (no more token secrets!)
  - ✅ Added coverage flags for better tracking

### Development Workflow
- **Pre-commit hooks** (`.pre-commit-config.yaml`):
  - Updated hook to run `coverage run -m pytest`
  - Includes coverage report and target validation

## Impact

### Coverage Accuracy
- **types.py**: 28% → 100% ✨
- **Overall src/**: 64% → 99% ✨
- Coverage now accurately tracks ALL code including plugin initialization

### What's Now Measured
- ✅ Import statements and `from __future__ import annotations`
- ✅ Class definitions and enum value assignments
- ✅ Decorators (@property, @require, @ensure, @abstractmethod)
- ✅ All plugin initialization code

## Testing

- ✅ All 199 tests passing locally
- ✅ Coverage validation passes (99% overall)
- ✅ Pre-commit hooks pass with new configuration
- ✅ No behavior changes to production code

## Documentation

The coverage infrastructure change is fully documented in:
- CLAUDE.md testing commands section with explanation
- This PR description
- Commit message with detailed root cause analysis
- Issue #9 comment with progress update

## Related

- Fixes the coverage measurement issue discovered in #9
- Follows up on PR #16 which was merged before this fix was pushed

---

**Note**: This PR contains only the infrastructure changes. The actual test coverage improvements from PR #16 were already merged to main.