### PR TITLE
fix(ci): Remove conflicting CodeQL workflow (use default setup)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,41 +56,6 @@ jobs:
           path: safety-report.json
           retention-days: 30
 
-  codeql-analysis:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      security-events: write
-      actions: read
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: python
-          queries: security-extended,security-and-quality
-
-      - name: Install dependencies
-        run: uv sync --all-groups
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:python"
-
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes #30

Removes the custom CodeQL Analysis job from the security workflow to resolve conflicts with GitHub's default CodeQL setup.

## Problem

All dependabot PRs were failing with:
```
CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled
```

The repository has GitHub's **CodeQL default setup** enabled in Security settings, which conflicts with custom CodeQL workflows. GitHub doesn't allow both configurations simultaneously.

## Solution

**Removed the `codeql-analysis` job** from `.github/workflows/security.yml` and rely on GitHub's automatic default setup instead.

### Why This Approach?

1. **Default setup is already configured** - Covers Python and GitHub Actions
2. **Zero maintenance** - Automatic updates from GitHub
3. **Still secure** - Default queries are comprehensive
4. **Other security checks remain** - Safety, Dependency Review, and OpenSSF Scorecard are still active

### What's Changing?

**Removed:**
- Custom `codeql-analysis` job with extended query suites

**Keeping:**
- GitHub's automatic CodeQL default setup (configured in Settings)
- Dependency Security Scan (Safety checks)
- Dependency Review (for PRs)
- OpenSSF Scorecard (scheduled)

## Testing

The fix will be verified by:
- No CodeQL workflow conflicts in CI
- Default CodeQL setup continues to run automatically
- Dependabot PRs can pass all security checks

## Impact

- Unblocks all dependabot PRs
- Maintains comprehensive security scanning
- Reduces workflow maintenance overhead
- No changes to production code or test behavior