### PR TITLE
fix(ci): Remove auto-approve step from dependabot workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,16 +22,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Auto-approve patch and minor updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: |
-          gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge for patch and minor updates
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
## Summary

Fixes #32

Removes the auto-approve step from the dependabot auto-merge workflow that was failing due to GitHub security restrictions.

## Problem

The auto-approve step was failing with:
```
GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)
```

This is a GitHub security restriction - `GITHUB_TOKEN` cannot approve PRs to prevent workflows from bypassing review requirements.

## Solution

**Removed the auto-approve step** since it's not needed now that auto-merge is enabled at the repository level.

### How Auto-Merge Works Now

1. Dependabot creates a PR
2. Workflow enables auto-merge on the PR
3. Once all required checks pass, GitHub automatically merges the PR
4. No approval needed (unless branch protection requires it)

### What Changed

**Removed:**
- `Auto-approve patch and minor updates` step (lines 25-33)

**Kept:**
- `Enable auto-merge for patch and minor updates` step
- `Comment on major updates` step
- All other workflow logic

## Benefits

- Fixes the failing auto-merge workflow
- Simplifies the workflow by removing unnecessary approval logic
- Works correctly with repository-level auto-merge setting
- Still handles major version updates with manual review comments

## Testing

The fix will be verified by:
- Dependabot PRs no longer failing on the approval step
- Auto-merge working correctly once checks pass
- Major version updates still getting manual review comments