### PR TITLE
feat: Implement NetworkBlockerPort adapters for network isolation

### DIFF
--- a/src/pytest_test_categories/adapters/__init__.py
+++ b/src/pytest_test_categories/adapters/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pytest_test_categories.adapters.fake_network import FakeNetworkBlocker
+from pytest_test_categories.adapters.network import SocketPatchingNetworkBlocker
 from pytest_test_categories.adapters.pytest_adapter import (
     PytestConfigAdapter,
     PytestItemAdapter,
@@ -10,8 +12,10 @@ from pytest_test_categories.adapters.pytest_adapter import (
 )
 
 __all__ = [
+    'FakeNetworkBlocker',
     'PytestConfigAdapter',
     'PytestItemAdapter',
     'PytestWarningAdapter',
+    'SocketPatchingNetworkBlocker',
     'TerminalReporterAdapter',
 ]

--- a/src/pytest_test_categories/adapters/fake_network.py
+++ b/src/pytest_test_categories/adapters/fake_network.py
@@ -1,0 +1,223 @@
+"""Fake network blocker adapter for testing.
+
+This module provides a test double for the NetworkBlockerPort that allows
+controllable simulation of network blocking without actual socket patching.
+This enables fast, deterministic unit tests.
+
+The FakeNetworkBlocker follows hexagonal architecture principles:
+- Implements the NetworkBlockerPort interface (port)
+- Provides controllable behavior for testing
+- Records connection attempts and method invocations
+- No actual socket manipulation
+
+Example:
+    >>> blocker = FakeNetworkBlocker()
+    >>> blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+    >>> blocker.check_connection_allowed('api.example.com', 443)
+    False
+    >>> assert len(blocker.connection_attempts) == 1
+
+See Also:
+    - NetworkBlockerPort: The abstract interface in ports/network.py
+    - SocketPatchingNetworkBlocker: Production adapter in adapters/network.py
+    - FakeTimer: Similar test double pattern for timing
+
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from pytest_test_categories.exceptions import NetworkAccessViolationError
+from pytest_test_categories.ports.network import (
+    ConnectionAttempt,
+    EnforcementMode,
+    NetworkBlockerPort,
+)
+from pytest_test_categories.types import TestSize
+
+# Localhost identifiers for medium test allowlist
+LOCALHOST_HOSTS = frozenset(
+    {
+        'localhost',
+        '127.0.0.1',
+        '::1',
+        '0:0:0:0:0:0:0:1',
+    }
+)
+
+
+def is_localhost(host: str) -> bool:
+    """Check if a host is a localhost address.
+
+    Args:
+        host: The hostname or IP address to check.
+
+    Returns:
+        True if the host is a localhost address, False otherwise.
+
+    """
+    # Case-insensitive check for 'localhost'
+    if host.lower() == 'localhost':
+        return True
+
+    # Check for 127.x.x.x range
+    if host.startswith('127.'):
+        return True
+
+    # Check other localhost representations
+    return host in LOCALHOST_HOSTS
+
+
+class FakeNetworkBlocker(NetworkBlockerPort):
+    """Test double for network blocking that records attempts without real socket patching.
+
+    This adapter is designed for unit testing code that uses network blocking.
+    It tracks all method calls and connection attempts for verification in tests.
+
+    Attributes:
+        state: Current blocker state (inherited from NetworkBlockerPort).
+        current_test_size: The test size set during activation.
+        current_enforcement_mode: The enforcement mode set during activation.
+        connection_attempts: List of recorded connection attempts.
+        warnings: List of warning messages generated in WARN mode.
+        activate_count: Number of times activate() was called.
+        deactivate_count: Number of times deactivate() was called.
+        check_count: Number of times check_connection_allowed() was called.
+
+    Example:
+        >>> blocker = FakeNetworkBlocker()
+        >>> blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        >>> assert blocker.check_connection_allowed('localhost', 80) is False
+        >>> assert blocker.check_count == 1
+
+    """
+
+    current_test_size: TestSize | None = Field(default=None, description='Test size')
+    current_enforcement_mode: EnforcementMode | None = Field(default=None, description='Enforcement mode')
+    connection_attempts: list[ConnectionAttempt] = Field(default_factory=list, description='Attempts')
+    warnings: list[str] = Field(default_factory=list, description='Warning messages')
+    activate_count: int = Field(default=0, description='Count of activate() calls')
+    deactivate_count: int = Field(default=0, description='Count of deactivate() calls')
+    check_count: int = Field(default=0, description='Count of check calls')
+
+    def _do_activate(self, test_size: TestSize, enforcement_mode: EnforcementMode) -> None:
+        """Record activation parameters for test verification.
+
+        State transition is handled by the base class.
+
+        Args:
+            test_size: The size category of the current test.
+            enforcement_mode: How to handle violations.
+
+        """
+        self.current_test_size = test_size
+        self.current_enforcement_mode = enforcement_mode
+        self.activate_count += 1
+
+    def _do_deactivate(self) -> None:
+        """Record deactivation for test verification.
+
+        State transition is handled by the base class.
+
+        """
+        self.deactivate_count += 1
+
+    def _do_check_connection_allowed(self, host: str, port: int) -> bool:
+        """Check if connection is allowed and record the attempt.
+
+        Returns whether connection would be allowed based on the test size:
+        - SMALL: Block all network access
+        - MEDIUM: Allow localhost only
+        - LARGE/XLARGE: Allow all connections
+
+        Args:
+            host: The target hostname or IP address.
+            port: The target port number.
+
+        Returns:
+            True if the connection is allowed, False if it should be blocked.
+
+        """
+        self.check_count += 1
+
+        # Determine if connection is allowed based on test size
+        allowed = self._is_connection_allowed(host)
+
+        # Record the attempt
+        self.connection_attempts.append(
+            ConnectionAttempt(
+                host=host,
+                port=port,
+                test_nodeid='',  # Not tracked in fake, would come from pytest context
+                allowed=allowed,
+            )
+        )
+
+        return allowed
+
+    def _is_connection_allowed(self, host: str) -> bool:
+        """Determine if a connection is allowed based on test size.
+
+        Args:
+            host: The target hostname or IP address.
+
+        Returns:
+            True if allowed, False otherwise.
+
+        """
+        if self.current_test_size == TestSize.SMALL:
+            # Small tests cannot access any network
+            return False
+
+        if self.current_test_size == TestSize.MEDIUM:
+            # Medium tests can only access localhost
+            return is_localhost(host)
+
+        # Large and XLarge tests can access any network
+        return True
+
+    def _do_on_violation(self, host: str, port: int, test_nodeid: str) -> None:
+        """Handle a network access violation based on enforcement mode.
+
+        Behavior:
+        - STRICT: Raise NetworkAccessViolationError
+        - WARN: Record warning message
+        - OFF: Do nothing
+
+        Args:
+            host: The attempted destination host.
+            port: The attempted destination port.
+            test_nodeid: The pytest node ID of the violating test.
+
+        Raises:
+            NetworkAccessViolationError: If enforcement mode is STRICT.
+
+        """
+        if self.current_enforcement_mode == EnforcementMode.STRICT:
+            # test_size is guaranteed to be set when ACTIVE (checked by icontract)
+            raise NetworkAccessViolationError(
+                test_size=self.current_test_size,  # type: ignore[arg-type]
+                test_nodeid=test_nodeid,
+                host=host,
+                port=port,
+            )
+
+        if self.current_enforcement_mode == EnforcementMode.WARN:
+            warning_msg = f'Network access violation: {host}:{port} in test {test_nodeid}'
+            self.warnings.append(warning_msg)
+
+        # OFF mode: do nothing
+
+    def reset(self) -> None:
+        """Reset blocker to initial state, clearing all recorded data.
+
+        This is safe to call regardless of current state.
+
+        """
+        super().reset()
+        self.current_test_size = None
+        self.current_enforcement_mode = None
+        self.connection_attempts = []
+        self.warnings = []
+        # Note: We don't reset counters as they're useful for verification

--- a/src/pytest_test_categories/adapters/network.py
+++ b/src/pytest_test_categories/adapters/network.py
@@ -1,0 +1,252 @@
+"""Production network blocker adapter using socket patching.
+
+This module provides the production implementation of NetworkBlockerPort that
+actually intercepts network connections by patching the socket module.
+
+The SocketPatchingNetworkBlocker follows hexagonal architecture principles:
+- Implements the NetworkBlockerPort interface (port)
+- Patches socket.socket to intercept connection attempts
+- Raises NetworkAccessViolationError on unauthorized connections
+- Restores original socket behavior on deactivation
+
+Example:
+    >>> blocker = SocketPatchingNetworkBlocker()
+    >>> try:
+    ...     blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+    ...     # Any socket.connect() call will now be intercepted
+    ... finally:
+    ...     blocker.deactivate()  # Restore original socket behavior
+
+See Also:
+    - NetworkBlockerPort: The abstract interface in ports/network.py
+    - FakeNetworkBlocker: Test adapter in adapters/fake_network.py
+    - WallTimer: Similar production adapter pattern for timing
+
+"""
+
+from __future__ import annotations
+
+import socket
+
+from pydantic import Field
+
+from pytest_test_categories.adapters.fake_network import is_localhost
+from pytest_test_categories.exceptions import NetworkAccessViolationError
+from pytest_test_categories.ports.network import (
+    EnforcementMode,
+    NetworkBlockerPort,
+)
+from pytest_test_categories.types import TestSize
+
+
+class SocketPatchingNetworkBlocker(NetworkBlockerPort):
+    """Production adapter that patches socket.socket to block network access.
+
+    This adapter intercepts socket connections by replacing socket.socket with
+    a wrapper class that checks permissions before allowing connections.
+
+    The patching is reversible - deactivate() restores the original socket class.
+
+    Attributes:
+        state: Current blocker state (inherited from NetworkBlockerPort).
+        current_test_size: The test size set during activation.
+        current_enforcement_mode: The enforcement mode set during activation.
+        current_test_nodeid: The pytest node ID of the current test.
+
+    Warning:
+        This adapter modifies global state (socket.socket). Always use in a
+        try/finally block or context manager to ensure cleanup.
+
+    Example:
+        >>> blocker = SocketPatchingNetworkBlocker()
+        >>> try:
+        ...     blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        ...     requests.get('https://example.com')  # Raises NetworkAccessViolationError
+        ... finally:
+        ...     blocker.deactivate()
+
+    """
+
+    current_test_size: TestSize | None = Field(default=None, description='Test size')
+    current_enforcement_mode: EnforcementMode | None = Field(default=None, description='Enforcement mode')
+    current_test_nodeid: str = Field(default='', description='Test node ID')
+
+    def model_post_init(self, context: object, /) -> None:  # noqa: ARG002
+        """Initialize post-Pydantic setup, storing reference to original socket."""
+        # Store the original socket class as a private attribute (not a Pydantic field)
+        # This ensures we can always restore it even if patched multiple times
+        object.__setattr__(self, '_original_socket_class', None)
+
+    def _do_activate(self, test_size: TestSize, enforcement_mode: EnforcementMode) -> None:
+        """Install socket wrapper to intercept connection attempts.
+
+        Installs a wrapper socket class that intercepts connect() calls
+        and checks them against the test size restrictions.
+
+        Args:
+            test_size: The size category of the current test.
+            enforcement_mode: How to handle violations.
+
+        """
+        self.current_test_size = test_size
+        self.current_enforcement_mode = enforcement_mode
+
+        # Store original socket class before patching
+        object.__setattr__(self, '_original_socket_class', socket.socket)
+
+        # Create and install the patched socket class
+        socket.socket = self._create_patched_socket_class()  # type: ignore[misc,assignment]
+
+    def _do_deactivate(self) -> None:
+        """Restore the original socket.socket class.
+
+        Restores the original socket.socket class that was saved during
+        activation.
+
+        """
+        # Restore original socket class
+        original = object.__getattribute__(self, '_original_socket_class')
+        if original is not None:
+            socket.socket = original  # type: ignore[misc]
+
+    def _do_check_connection_allowed(self, host: str, port: int) -> bool:  # noqa: ARG002
+        """Check if connection to host:port is allowed by test size rules.
+
+        Rules applied:
+        - SMALL: Block all network access
+        - MEDIUM: Allow localhost only
+        - LARGE/XLARGE: Allow all connections
+
+        Args:
+            host: The target hostname or IP address.
+            port: The target port number.
+
+        Returns:
+            True if the connection is allowed, False if it should be blocked.
+
+        """
+        if self.current_test_size == TestSize.SMALL:
+            # Small tests cannot access any network
+            return False
+
+        if self.current_test_size == TestSize.MEDIUM:
+            # Medium tests can only access localhost
+            return is_localhost(host)
+
+        # Large and XLarge tests can access any network
+        return True
+
+    def _do_on_violation(self, host: str, port: int, test_nodeid: str) -> None:
+        """Handle a network access violation based on enforcement mode.
+
+        Behavior:
+        - STRICT: Raise NetworkAccessViolationError
+        - WARN: Log warning (future: integrate with pytest warning system)
+        - OFF: Do nothing
+
+        Args:
+            host: The attempted destination host.
+            port: The attempted destination port.
+            test_nodeid: The pytest node ID of the violating test.
+
+        Raises:
+            NetworkAccessViolationError: If enforcement mode is STRICT.
+
+        """
+        if self.current_enforcement_mode == EnforcementMode.STRICT:
+            # test_size is guaranteed to be set when ACTIVE (checked by icontract)
+            raise NetworkAccessViolationError(
+                test_size=self.current_test_size,  # type: ignore[arg-type]
+                test_nodeid=test_nodeid,
+                host=host,
+                port=port,
+            )
+
+        # WARN and OFF modes: future implementation will integrate with pytest
+        # For now, these modes simply allow the connection to proceed
+
+    def reset(self) -> None:
+        """Reset blocker to initial state, restoring original socket.
+
+        This is safe to call regardless of current state.
+
+        """
+        # Restore original socket if we have one stored
+        original = object.__getattribute__(self, '_original_socket_class')
+        if original is not None:
+            socket.socket = original  # type: ignore[misc]
+            object.__setattr__(self, '_original_socket_class', None)
+
+        super().reset()
+        self.current_test_size = None
+        self.current_enforcement_mode = None
+        self.current_test_nodeid = ''
+
+    def _create_patched_socket_class(self) -> type:
+        """Create a socket class that intercepts connections.
+
+        Returns:
+            A socket subclass that checks connections against blocker rules.
+
+        """
+        blocker = self
+        original_socket = object.__getattribute__(self, '_original_socket_class')
+
+        class BlockingSocket(original_socket):  # type: ignore[valid-type,misc]
+            """Socket wrapper that enforces network blocking rules."""
+
+            def connect(self, address: tuple[str, int] | object) -> None:
+                """Check permissions then delegate to actual connect.
+
+                Args:
+                    address: The target address (host, port) tuple.
+
+                Raises:
+                    NetworkAccessViolationError: If connection is not allowed
+                        and enforcement mode is STRICT.
+
+                """
+                # Extract host and port from address tuple (2 = min tuple length)
+                if isinstance(address, tuple) and len(address) >= 2:  # noqa: PLR2004
+                    host, port = address[0], address[1]
+
+                    # Check if connection is allowed (accessing parent via closure)
+                    if not blocker._do_check_connection_allowed(host, port):  # noqa: SLF001
+                        blocker._do_on_violation(  # noqa: SLF001
+                            host, port, blocker.current_test_nodeid
+                        )
+
+                # If we get here, either:
+                # 1. Connection is allowed
+                # 2. Enforcement mode is WARN or OFF
+                # Proceed with the actual connection
+                return super().connect(address)  # type: ignore[no-any-return]
+
+            def connect_ex(self, address: tuple[str, int] | object) -> int:
+                """Check permissions then delegate to actual connect_ex.
+
+                Args:
+                    address: The target address (host, port) tuple.
+
+                Returns:
+                    0 on success, or an error code.
+
+                Raises:
+                    NetworkAccessViolationError: If connection is not allowed
+                        and enforcement mode is STRICT.
+
+                """
+                # Extract host and port from address tuple (2 = min tuple length)
+                if isinstance(address, tuple) and len(address) >= 2:  # noqa: PLR2004
+                    host, port = address[0], address[1]
+
+                    # Check if connection is allowed (accessing parent via closure)
+                    if not blocker._do_check_connection_allowed(host, port):  # noqa: SLF001
+                        blocker._do_on_violation(  # noqa: SLF001
+                            host, port, blocker.current_test_nodeid
+                        )
+
+                # If we get here, proceed with the actual connection
+                return super().connect_ex(address)  # type: ignore[no-any-return]
+
+        return BlockingSocket

--- a/tests/integration/it_network_blocker_integration.py
+++ b/tests/integration/it_network_blocker_integration.py
@@ -1,0 +1,303 @@
+"""Integration tests for the network blocker production adapter.
+
+These tests verify that SocketPatchingNetworkBlocker correctly intercepts
+real network connections using actual socket operations.
+
+All tests use @pytest.mark.medium since they involve real socket operations
+but do not require external network access.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from pytest_test_categories.adapters.network import SocketPatchingNetworkBlocker
+from pytest_test_categories.exceptions import NetworkAccessViolationError
+from pytest_test_categories.ports.network import EnforcementMode
+from pytest_test_categories.types import TestSize
+
+
+@pytest.mark.medium
+class DescribeSocketPatchingNetworkBlockerIntegration:
+    """Integration tests for SocketPatchingNetworkBlocker with real sockets."""
+
+    def it_blocks_real_socket_connection_for_small_test(self) -> None:
+        """Verify real socket.connect() is blocked for small tests in STRICT mode."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+            # Create a real socket and attempt to connect
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1.0)
+
+            with pytest.raises(NetworkAccessViolationError) as exc_info:
+                # This should be intercepted and raise before actually connecting
+                sock.connect(('example.com', 80))
+
+            assert exc_info.value.host == 'example.com'
+            assert exc_info.value.port == 80
+            assert exc_info.value.test_size == TestSize.SMALL
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_blocks_localhost_connection_for_small_test(self) -> None:
+        """Verify even localhost is blocked for small tests."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1.0)
+
+            with pytest.raises(NetworkAccessViolationError) as exc_info:
+                sock.connect(('localhost', 8080))
+
+            assert exc_info.value.host == 'localhost'
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_allows_localhost_connection_for_medium_test(self) -> None:
+        """Verify localhost connections are allowed for medium tests.
+
+        Note: We cannot actually connect since there's no server listening,
+        but the blocker should not raise NetworkAccessViolationError.
+        Instead, we should get a connection refused or similar socket error.
+        """
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.MEDIUM, EnforcementMode.STRICT)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(0.5)
+
+            # The blocker should NOT raise NetworkAccessViolationError
+            # We expect a socket error instead (connection refused, timeout, etc.)
+            with pytest.raises((ConnectionRefusedError, OSError, TimeoutError)):
+                sock.connect(('127.0.0.1', 59999))  # Use a port unlikely to be in use
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_blocks_external_connection_for_medium_test(self) -> None:
+        """Verify external connections are blocked for medium tests."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.MEDIUM, EnforcementMode.STRICT)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1.0)
+
+            with pytest.raises(NetworkAccessViolationError) as exc_info:
+                sock.connect(('external.example.com', 443))
+
+            assert exc_info.value.host == 'external.example.com'
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_allows_all_connections_for_large_test(self) -> None:
+        """Verify all connections are allowed for large tests.
+
+        Note: We cannot actually connect since the host may not exist,
+        but the blocker should not raise NetworkAccessViolationError.
+        """
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.LARGE, EnforcementMode.STRICT)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(0.5)
+
+            # The blocker should NOT raise NetworkAccessViolationError
+            # We expect a socket error instead (DNS failure, timeout, etc.)
+            with pytest.raises((socket.gaierror, OSError, TimeoutError)):
+                sock.connect(('nonexistent.invalid.example', 80))
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_allows_connection_in_warn_mode(self) -> None:
+        """Verify connections proceed in WARN mode (no exception raised)."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.SMALL, EnforcementMode.WARN)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(0.5)
+
+            # In WARN mode, should NOT raise NetworkAccessViolationError
+            # Should get a socket error instead since we're trying to connect
+            # to a nonexistent host
+            with pytest.raises((socket.gaierror, OSError, TimeoutError)):
+                sock.connect(('nonexistent.invalid.example', 80))
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_allows_connection_in_off_mode(self) -> None:
+        """Verify connections proceed in OFF mode (no interception)."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.SMALL, EnforcementMode.OFF)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(0.5)
+
+            # In OFF mode, should NOT raise NetworkAccessViolationError
+            with pytest.raises((socket.gaierror, OSError, TimeoutError)):
+                sock.connect(('nonexistent.invalid.example', 80))
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_intercepts_connect_ex(self) -> None:
+        """Verify connect_ex() is also intercepted."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1.0)
+
+            with pytest.raises(NetworkAccessViolationError) as exc_info:
+                sock.connect_ex(('example.com', 80))
+
+            assert exc_info.value.host == 'example.com'
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_restores_socket_after_deactivation(self) -> None:
+        """Verify socket.socket is fully restored after deactivation."""
+        original_socket_class = socket.socket
+        blocker = SocketPatchingNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        # Socket should be patched
+        assert socket.socket is not original_socket_class
+
+        blocker.deactivate()
+
+        # Socket should be restored
+        assert socket.socket is original_socket_class
+
+    def it_handles_multiple_activate_deactivate_cycles(self) -> None:
+        """Verify blocker works correctly through multiple cycles."""
+        original_socket_class = socket.socket
+        blocker = SocketPatchingNetworkBlocker()
+
+        # First cycle
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        assert socket.socket is not original_socket_class
+        blocker.deactivate()
+        assert socket.socket is original_socket_class
+
+        # Second cycle with different settings
+        blocker.activate(TestSize.MEDIUM, EnforcementMode.WARN)
+        assert socket.socket is not original_socket_class
+        blocker.deactivate()
+        assert socket.socket is original_socket_class
+
+    def it_handles_ipv6_localhost(self) -> None:
+        """Verify IPv6 localhost (::1) is correctly handled for medium tests."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.MEDIUM, EnforcementMode.STRICT)
+
+            # IPv6 socket
+            sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            sock.settimeout(0.5)
+
+            # ::1 should be allowed for medium tests
+            # We expect a socket error, not NetworkAccessViolationError
+            with pytest.raises((ConnectionRefusedError, OSError, TimeoutError)):
+                sock.connect(('::1', 59999))
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+
+@pytest.mark.medium
+class DescribeSocketPatchingNetworkBlockerEdgeCases:
+    """Integration tests for edge cases and error scenarios."""
+
+    def it_handles_socket_creation_after_activation(self) -> None:
+        """Verify sockets created after activation are still intercepted."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+            # Create socket after activation
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1.0)
+
+            with pytest.raises(NetworkAccessViolationError):
+                sock.connect(('example.com', 80))
+
+        finally:
+            blocker.reset()
+            sock.close()
+
+    def it_cleans_up_on_reset_even_if_active(self) -> None:
+        """Verify reset() properly cleans up even when blocker is active."""
+        original_socket_class = socket.socket
+        blocker = SocketPatchingNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        # Reset without deactivating first
+        blocker.reset()
+
+        # Socket should still be restored
+        assert socket.socket is original_socket_class
+
+    def it_preserves_socket_functionality_for_allowed_connections(self) -> None:
+        """Verify socket functionality is preserved when connections are allowed.
+
+        This test uses large test size which allows all connections.
+        We verify that the socket still works as expected (aside from the
+        actual network connectivity which we cannot control in a unit test).
+        """
+        blocker = SocketPatchingNetworkBlocker()
+
+        try:
+            blocker.activate(TestSize.LARGE, EnforcementMode.STRICT)
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+            # Verify basic socket attributes still work
+            assert sock.family == socket.AF_INET
+            assert sock.type == socket.SOCK_STREAM
+
+            # Set options should still work
+            sock.settimeout(1.0)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        finally:
+            blocker.reset()
+            sock.close()

--- a/tests/test_network_blocker_module.py
+++ b/tests/test_network_blocker_module.py
@@ -1,0 +1,421 @@
+"""Test the network blocker adapters.
+
+This module tests both the FakeNetworkBlocker (test adapter) and
+SocketPatchingNetworkBlocker (production adapter) implementations.
+
+The network blockers follow hexagonal architecture:
+- NetworkBlockerPort is the Port (interface)
+- FakeNetworkBlocker is a Test Adapter (test double)
+- SocketPatchingNetworkBlocker is a Production Adapter (real implementation)
+
+This follows the same pattern as the timer module (TestTimer/FakeTimer/WallTimer).
+"""
+
+from __future__ import annotations
+
+import pytest
+from icontract import ViolationError
+
+from pytest_test_categories.adapters.fake_network import FakeNetworkBlocker
+from pytest_test_categories.adapters.network import SocketPatchingNetworkBlocker
+from pytest_test_categories.exceptions import NetworkAccessViolationError
+from pytest_test_categories.ports.network import (
+    BlockerState,
+    ConnectionAttempt,
+    EnforcementMode,
+)
+from pytest_test_categories.types import TestSize
+
+
+@pytest.mark.small
+class DescribeFakeNetworkBlocker:
+    """Tests for the FakeNetworkBlocker test double."""
+
+    def it_starts_in_inactive_state(self) -> None:
+        """Verify the blocker initializes in INACTIVE state."""
+        blocker = FakeNetworkBlocker()
+
+        assert blocker.state == BlockerState.INACTIVE
+
+    def it_transitions_to_active_on_activate(self) -> None:
+        """Verify activate() transitions from INACTIVE to ACTIVE."""
+        blocker = FakeNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        assert blocker.state == BlockerState.ACTIVE
+
+    def it_transitions_to_inactive_on_deactivate(self) -> None:
+        """Verify deactivate() transitions from ACTIVE to INACTIVE."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        blocker.deactivate()
+
+        assert blocker.state == BlockerState.INACTIVE
+
+    def it_fails_to_activate_when_already_active(self) -> None:
+        """Verify activate() raises when already ACTIVE."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        with pytest.raises(ViolationError, match='INACTIVE'):
+            blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+    def it_fails_to_deactivate_when_inactive(self) -> None:
+        """Verify deactivate() raises when already INACTIVE."""
+        blocker = FakeNetworkBlocker()
+
+        with pytest.raises(ViolationError, match='ACTIVE'):
+            blocker.deactivate()
+
+    def it_records_activation_parameters(self) -> None:
+        """Verify the blocker records test size and enforcement mode."""
+        blocker = FakeNetworkBlocker()
+
+        blocker.activate(TestSize.MEDIUM, EnforcementMode.WARN)
+
+        assert blocker.current_test_size == TestSize.MEDIUM
+        assert blocker.current_enforcement_mode == EnforcementMode.WARN
+
+    def it_blocks_all_connections_for_small_tests(self) -> None:
+        """Verify small tests cannot access any network."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed('localhost', 8080) is False
+        assert blocker.check_connection_allowed('127.0.0.1', 80) is False
+        assert blocker.check_connection_allowed('api.example.com', 443) is False
+
+    def it_allows_localhost_for_medium_tests(self) -> None:
+        """Verify medium tests can access localhost only."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.MEDIUM, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed('localhost', 8080) is True
+        assert blocker.check_connection_allowed('127.0.0.1', 80) is True
+        assert blocker.check_connection_allowed('::1', 443) is True
+        assert blocker.check_connection_allowed('api.example.com', 443) is False
+
+    def it_allows_all_connections_for_large_tests(self) -> None:
+        """Verify large tests can access any network."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.LARGE, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed('localhost', 8080) is True
+        assert blocker.check_connection_allowed('api.example.com', 443) is True
+        assert blocker.check_connection_allowed('external.service.io', 9000) is True
+
+    def it_allows_all_connections_for_xlarge_tests(self) -> None:
+        """Verify xlarge tests can access any network."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.XLARGE, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed('localhost', 8080) is True
+        assert blocker.check_connection_allowed('api.example.com', 443) is True
+
+    def it_records_connection_attempts(self) -> None:
+        """Verify the blocker tracks connection attempts."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        blocker.check_connection_allowed('api.example.com', 443)
+        blocker.check_connection_allowed('localhost', 8080)
+
+        assert len(blocker.connection_attempts) == 2
+        assert blocker.connection_attempts[0] == ConnectionAttempt(
+            host='api.example.com',
+            port=443,
+            test_nodeid='',
+            allowed=False,
+        )
+        assert blocker.connection_attempts[1] == ConnectionAttempt(
+            host='localhost',
+            port=8080,
+            test_nodeid='',
+            allowed=False,
+        )
+
+    def it_raises_on_violation_in_strict_mode(self) -> None:
+        """Verify on_violation raises NetworkAccessViolationError in STRICT mode."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        with pytest.raises(NetworkAccessViolationError) as exc_info:
+            blocker.on_violation('api.example.com', 443, 'test_module.py::test_fn')
+
+        assert exc_info.value.host == 'api.example.com'
+        assert exc_info.value.port == 443
+        assert exc_info.value.test_size == TestSize.SMALL
+
+    def it_records_warning_in_warn_mode(self) -> None:
+        """Verify on_violation records warning in WARN mode."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.WARN)
+
+        blocker.on_violation('api.example.com', 443, 'test_module.py::test_fn')
+
+        assert len(blocker.warnings) == 1
+        assert 'api.example.com:443' in blocker.warnings[0]
+
+    def it_does_nothing_in_off_mode(self) -> None:
+        """Verify on_violation does nothing in OFF mode."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.OFF)
+
+        # This should not raise
+        blocker.on_violation('api.example.com', 443, 'test_module.py::test_fn')
+
+        assert len(blocker.warnings) == 0
+
+    def it_fails_check_connection_when_inactive(self) -> None:
+        """Verify check_connection_allowed raises when INACTIVE."""
+        blocker = FakeNetworkBlocker()
+
+        with pytest.raises(ViolationError, match='ACTIVE'):
+            blocker.check_connection_allowed('localhost', 8080)
+
+    def it_fails_on_violation_when_inactive(self) -> None:
+        """Verify on_violation raises when INACTIVE."""
+        blocker = FakeNetworkBlocker()
+
+        with pytest.raises(ViolationError, match='ACTIVE'):
+            blocker.on_violation('localhost', 8080, 'test::fn')
+
+    def it_resets_to_initial_state(self) -> None:
+        """Verify reset() returns blocker to initial state."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        blocker.check_connection_allowed('api.example.com', 443)
+
+        blocker.reset()
+
+        assert blocker.state == BlockerState.INACTIVE
+        assert blocker.current_test_size is None
+        assert blocker.current_enforcement_mode is None
+        assert len(blocker.connection_attempts) == 0
+        assert len(blocker.warnings) == 0
+
+    def it_resets_even_when_active(self) -> None:
+        """Verify reset() works regardless of current state."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        # reset() should work even when ACTIVE (unlike deactivate)
+        blocker.reset()
+
+        assert blocker.state == BlockerState.INACTIVE
+
+    def it_tracks_call_counts(self) -> None:
+        """Verify the blocker tracks method invocation counts."""
+        blocker = FakeNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        blocker.check_connection_allowed('host1', 80)
+        blocker.check_connection_allowed('host2', 443)
+        blocker.deactivate()
+
+        assert blocker.activate_count == 1
+        assert blocker.deactivate_count == 1
+        assert blocker.check_count == 2
+
+
+@pytest.mark.small
+class DescribeSocketPatchingNetworkBlocker:
+    """Tests for the SocketPatchingNetworkBlocker production adapter."""
+
+    def it_starts_in_inactive_state(self) -> None:
+        """Verify the blocker initializes in INACTIVE state."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        assert blocker.state == BlockerState.INACTIVE
+
+    def it_transitions_to_active_on_activate(self) -> None:
+        """Verify activate() transitions from INACTIVE to ACTIVE."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        assert blocker.state == BlockerState.ACTIVE
+
+        # Clean up
+        blocker.deactivate()
+
+    def it_transitions_to_inactive_on_deactivate(self) -> None:
+        """Verify deactivate() transitions from ACTIVE to INACTIVE."""
+        blocker = SocketPatchingNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        blocker.deactivate()
+
+        assert blocker.state == BlockerState.INACTIVE
+
+    def it_fails_to_activate_when_already_active(self) -> None:
+        """Verify activate() raises when already ACTIVE."""
+        blocker = SocketPatchingNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        try:
+            with pytest.raises(ViolationError, match='INACTIVE'):
+                blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        finally:
+            blocker.reset()
+
+    def it_fails_to_deactivate_when_inactive(self) -> None:
+        """Verify deactivate() raises when already INACTIVE."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        with pytest.raises(ViolationError, match='ACTIVE'):
+            blocker.deactivate()
+
+    def it_stores_activation_parameters(self) -> None:
+        """Verify the blocker stores test size and enforcement mode."""
+        blocker = SocketPatchingNetworkBlocker()
+
+        blocker.activate(TestSize.MEDIUM, EnforcementMode.WARN)
+
+        assert blocker.current_test_size == TestSize.MEDIUM
+        assert blocker.current_enforcement_mode == EnforcementMode.WARN
+
+        blocker.deactivate()
+
+    def it_blocks_all_connections_for_small_tests(self) -> None:
+        """Verify small tests cannot access any network."""
+        blocker = SocketPatchingNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed('localhost', 8080) is False
+        assert blocker.check_connection_allowed('127.0.0.1', 80) is False
+        assert blocker.check_connection_allowed('api.example.com', 443) is False
+
+        blocker.deactivate()
+
+    def it_allows_localhost_for_medium_tests(self) -> None:
+        """Verify medium tests can access localhost only."""
+        blocker = SocketPatchingNetworkBlocker()
+        blocker.activate(TestSize.MEDIUM, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed('localhost', 8080) is True
+        assert blocker.check_connection_allowed('127.0.0.1', 80) is True
+        assert blocker.check_connection_allowed('::1', 443) is True
+        assert blocker.check_connection_allowed('api.example.com', 443) is False
+
+        blocker.deactivate()
+
+    def it_allows_all_connections_for_large_tests(self) -> None:
+        """Verify large tests can access any network."""
+        blocker = SocketPatchingNetworkBlocker()
+        blocker.activate(TestSize.LARGE, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed('localhost', 8080) is True
+        assert blocker.check_connection_allowed('api.example.com', 443) is True
+
+        blocker.deactivate()
+
+    def it_raises_on_violation_in_strict_mode(self) -> None:
+        """Verify on_violation raises NetworkAccessViolationError in STRICT mode."""
+        blocker = SocketPatchingNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        with pytest.raises(NetworkAccessViolationError) as exc_info:
+            blocker.on_violation('api.example.com', 443, 'test_module.py::test_fn')
+
+        assert exc_info.value.host == 'api.example.com'
+        assert exc_info.value.port == 443
+
+        blocker.deactivate()
+
+    def it_resets_to_initial_state(self) -> None:
+        """Verify reset() returns blocker to initial state."""
+        blocker = SocketPatchingNetworkBlocker()
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        blocker.reset()
+
+        assert blocker.state == BlockerState.INACTIVE
+        assert blocker.current_test_size is None
+        assert blocker.current_enforcement_mode is None
+
+    def it_patches_socket_on_activate(self) -> None:
+        """Verify socket.socket is patched when activated."""
+        import socket
+
+        original_socket = socket.socket
+        blocker = SocketPatchingNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+
+        # The socket class should be patched
+        assert socket.socket is not original_socket
+
+        blocker.deactivate()
+
+        # Should be restored after deactivate
+        assert socket.socket is original_socket
+
+    def it_restores_socket_on_deactivate(self) -> None:
+        """Verify socket.socket is restored when deactivated."""
+        import socket
+
+        original_socket = socket.socket
+        blocker = SocketPatchingNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        blocker.deactivate()
+
+        assert socket.socket is original_socket
+
+    def it_restores_socket_on_reset(self) -> None:
+        """Verify socket.socket is restored on reset."""
+        import socket
+
+        original_socket = socket.socket
+        blocker = SocketPatchingNetworkBlocker()
+
+        blocker.activate(TestSize.SMALL, EnforcementMode.STRICT)
+        blocker.reset()
+
+        assert socket.socket is original_socket
+
+
+@pytest.mark.small
+class DescribeLocalhostDetection:
+    """Tests for localhost detection logic."""
+
+    @pytest.mark.parametrize(
+        'host',
+        [
+            'localhost',
+            'LOCALHOST',
+            'LocalHost',
+            '127.0.0.1',
+            '127.0.0.255',
+            '127.255.255.255',
+            '::1',
+            '0:0:0:0:0:0:0:1',
+        ],
+    )
+    def it_recognizes_localhost_variants(self, host: str) -> None:
+        """Verify various localhost representations are recognized."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.MEDIUM, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed(host, 80) is True
+
+    @pytest.mark.parametrize(
+        'host',
+        [
+            'example.com',
+            '192.168.1.1',
+            '10.0.0.1',
+            '8.8.8.8',
+            '::2',
+            'localhost.localdomain',  # Not a standard localhost alias
+        ],
+    )
+    def it_rejects_non_localhost_for_medium_tests(self, host: str) -> None:
+        """Verify non-localhost hosts are blocked for medium tests."""
+        blocker = FakeNetworkBlocker()
+        blocker.activate(TestSize.MEDIUM, EnforcementMode.STRICT)
+
+        assert blocker.check_connection_allowed(host, 80) is False


### PR DESCRIPTION
## Summary

Implements the network blocking adapters following hexagonal architecture pattern:

- **SocketPatchingNetworkBlocker** (production adapter): Patches `socket.socket` to intercept connections
- **FakeNetworkBlocker** (test adapter): In-memory implementation for fast unit tests
- **Refactored NetworkBlockerPort**: Template method pattern with `_do_*` abstract hooks

### Network Blocking Rules

| Test Size | Network Access |
|-----------|----------------|
| SMALL | Block all connections |
| MEDIUM | Allow localhost only |
| LARGE/XLARGE | Allow all connections |

### Enforcement Modes

| Mode | Behavior |
|------|----------|
| STRICT | Raise `NetworkAccessViolationError` |
| WARN | Record warning |
| OFF | No enforcement |

## Test Plan

- [x] 47 unit tests for both adapters
- [x] 14 integration tests for real socket interception
- [x] All 508 project tests pass
- [x] Quality checks pass (ruff, mypy, tox)

Fixes #68