### PR TITLE
docs: Configure ReadTheDocs for documentation hosting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for pytest-test-categories
+# See https://docs.readthedocs.com/platform/en/stable/config-file/v2.html for details
+
+version: 2
+
+# Sphinx configuration
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false  # Project has some autoapi duplicate warnings
+
+# Build additional formats
+formats:
+  - pdf
+  - epub
+
+# Build configuration using uv package manager
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+  jobs:
+    # Install uv via asdf before environment creation
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+
+    # Create virtual environment using uv
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+
+    # Install dependencies using uv sync with docs group
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pytest Test Categories Plugin
 
+[![Documentation Status](https://readthedocs.org/projects/pytest-test-categories/badge/?version=latest)](https://pytest-test-categories.readthedocs.io/en/latest/?badge=latest)
+
 ## Overview
 
 **Pytest Test Categories** is a plugin designed to help developers enforce test timing constraints and size distributions in their test suites. This plugin provides an effective way to categorize tests by their execution time and ensures that the test distribution meets predefined targets for different test sizes.


### PR DESCRIPTION
## Summary

Configures ReadTheDocs to automatically build and host documentation for pytest-test-categories.

- Adds `.readthedocs.yaml` configuration with uv support and Sphinx setup
- Adds documentation status badge to README.md
- Enables PDF and EPUB format generation

## Changes

- **`.readthedocs.yaml`**: ReadTheDocs configuration using Ubuntu 24.04, Python 3.12, and uv for dependency management
- **`README.md`**: Added documentation status badge

## Test Plan

- [x] Local Sphinx build completes successfully
- [x] Pre-commit hooks pass
- [ ] After merge: Register project on ReadTheDocs and verify first build

## Manual Steps Required (Post-Merge)

1. Register the project on ReadTheDocs at https://readthedocs.org/
2. Import the `mikelane/pytest-test-categories` repository
3. Verify the first build completes successfully
4. Documentation will be available at https://pytest-test-categories.readthedocs.io/

Fixes #81