### PR TITLE
ci: Add TestPyPI validation workflow for pre-release testing

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       actions: write
@@ -90,6 +91,7 @@ jobs:
     name: Publish to TestPyPI
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: inputs.validate_testpypi
     environment:
       name: testpypi
@@ -119,6 +121,7 @@ jobs:
     name: Validate (${{ matrix.os }}, Python ${{ matrix.python-version }})
     needs: [build, publish-testpypi]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     if: inputs.validate_testpypi
     permissions:
       contents: read
@@ -126,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -182,6 +185,7 @@ jobs:
     name: TestPyPI Validation Summary
     needs: [build, publish-testpypi, validate-testpypi]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always() && inputs.validate_testpypi
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Implements a TestPyPI validation workflow that verifies package publishing works correctly before production PyPI releases, using Trusted Publishers (OIDC) authentication.

## Changes

- **`.github/workflows/test-release.yml`**: New workflow with 4 jobs:
  - `build`: Extracts version, generates dev suffix, builds package, runs tests
  - `publish-testpypi`: Publishes to TestPyPI using OIDC/Trusted Publishers
  - `validate-testpypi`: Matrix job (3 OS × 3 Python = 9 combinations) that installs from TestPyPI and runs smoke tests
  - `summary`: Creates GitHub Actions summary with validation results

## Key Features

- **Manual Trigger**: Uses `workflow_dispatch` with `validate_testpypi` boolean input
- **Dev Version Suffix**: Generates unique versions like `0.3.0.dev20241127123456` to avoid conflicts
- **OIDC Authentication**: No API tokens needed - uses Trusted Publishers
- **Cross-Platform Validation**: Tests on Ubuntu, macOS, and Windows with Python 3.11, 3.12, 3.13

## Test Plan

- [x] YAML syntax validated
- [x] Pre-commit hooks pass
- [ ] After setup: Manually trigger workflow and verify TestPyPI publishing

## Manual Steps Required (Post-Merge)

1. **TestPyPI Trusted Publisher Setup**:
   - Go to https://test.pypi.org/manage/account/publishing/
   - Add pending publisher: Owner=`mikelane`, Repo=`pytest-test-categories`, Workflow=`test-release.yml`, Environment=`testpypi`

2. **GitHub Environment**:
   - Create a `testpypi` environment in repository settings (no secrets needed)

Fixes #82