### PR TITLE
chore: add .python-version and poetry.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ coverage.json
 .vscode/
 .DS_Store
 .worktrees/
+.python-version
+poetry.lock
 
 # Sphinx documentation
 docs/_build/


### PR DESCRIPTION
## Summary

Adds two files to `.gitignore` that shouldn't be tracked:

- **`.python-version`**: Local pyenv/asdf config file. Since the project supports Python 3.11-3.14, contributors should use whatever version they have installed rather than a fixed version.

- **`poetry.lock`**: This project uses uv for dependency management, not poetry. Any stray poetry.lock files should be ignored.

## Test Plan

- [x] Pre-commit hooks pass
- [x] No functional changes