### PR TITLE
docs: add comprehensive filesystem isolation documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - TBD
+
+### Added
+
+- **Filesystem Isolation Design**: Architecture Decision Record (ADR-002) documenting the design for filesystem isolation in small tests (#91, #95)
+- **Filesystem Isolation Documentation**: Comprehensive documentation for the filesystem isolation feature including:
+  - User guide explaining filesystem isolation concepts and usage (#94)
+  - Troubleshooting guide for filesystem violations (#94)
+  - Examples demonstrating common patterns and fixes (#94)
+  - Configuration reference for allowed paths (#94)
+- **Configuration Options**: New configuration options for filesystem isolation (planned implementation):
+  - `test_categories_allowed_paths` ini option for configuring allowed filesystem paths
+  - `--test-categories-allowed-paths` CLI option for command-line configuration
+  - Per-test markers `@pytest.mark.allow_filesystem` and `@pytest.mark.allow_filesystem_paths` (planned)
+
+### Documentation
+
+- Updated user guide index with filesystem isolation information
+- Updated troubleshooting index with filesystem violations guide
+- Updated examples index with filesystem isolation examples
+- Updated configuration reference with new filesystem options
+- Added filesystem column to test size markers quick reference table
+
 ## [0.4.0] - 2025-11-27
 
 ### BREAKING CHANGE

--- a/README.md
+++ b/README.md
@@ -132,58 +132,78 @@ The plugin hooks into several pytest phases to:
 | Medium       | 15%               | 5%        |
 | Large/XLarge | 5%                | 3%        |
 
-## Network Isolation
+## Resource Isolation
 
-The plugin enforces network isolation for small tests to ensure test hermeticity. When enabled, small tests that attempt network access will fail immediately or emit warnings, depending on the enforcement mode.
+The plugin enforces resource isolation for small tests to ensure test hermeticity. When enabled, small tests that attempt network or filesystem access will fail immediately or emit warnings, depending on the enforcement mode.
 
-| Test Size | Network Access |
-|-----------|---------------|
-| Small     | **Blocked** - Must be hermetic |
-| Medium    | Allowed |
-| Large     | Allowed |
-| XLarge    | Allowed |
+| Test Size | Network Access | Filesystem Access |
+|-----------|---------------|-------------------|
+| Small     | **Blocked** | **Blocked*** |
+| Medium    | Allowed | Allowed |
+| Large     | Allowed | Allowed |
+| XLarge    | Allowed | Allowed |
+
+*Small tests can access `tmp_path`, system temp directories, and configured allowed paths.
 
 ### Configuration
 
-Network isolation enforcement is configured via `pyproject.toml`:
+Resource isolation enforcement is configured via `pyproject.toml`:
 
 ```toml
 [tool.pytest.ini_options]
 # Enforcement modes: "strict", "warn", "off"
 test_categories_enforcement = "strict"
+
+# Additional allowed paths for filesystem access in small tests
+test_categories_allowed_paths = [
+    "tests/fixtures/",
+]
 ```
 
 Or via command line (CLI option takes precedence over ini setting):
 
 ```bash
 pytest --test-categories-enforcement=strict
+pytest --test-categories-allowed-paths=tests/fixtures/
 ```
 
 ### Enforcement Modes
 
 | Mode | Behavior |
 |------|----------|
-| `strict` | Fail tests immediately on network violations |
+| `strict` | Fail tests immediately on violations |
 | `warn` | Emit warnings but allow tests to continue |
-| `off` | Disable network isolation enforcement (default) |
+| `off` | Disable isolation enforcement (default) |
 
 ### Per-Test Override (Planned)
 
-The `allow_network` marker will allow network access for specific tests:
+The `allow_network` and `allow_filesystem` markers will allow access for specific tests:
 
 ```python
 @pytest.mark.small
 @pytest.mark.allow_network  # Planned - not yet available
-def test_special_case():
+def test_special_case_network():
+    ...
+
+@pytest.mark.small
+@pytest.mark.allow_filesystem  # Planned - not yet available
+def test_special_case_filesystem():
     ...
 ```
 
 ### Documentation
 
+**Network Isolation:**
 - [User Guide: Network Isolation](docs/user-guide/network-isolation.md)
 - [Troubleshooting: Network Violations](docs/troubleshooting/network-violations.md)
 - [Examples: Network Isolation](docs/examples/network-isolation.md)
 - [ADR-001: Network Isolation Architecture](docs/architecture/adr-001-network-isolation.md)
+
+**Filesystem Isolation:**
+- [User Guide: Filesystem Isolation](docs/user-guide/filesystem-isolation.md)
+- [Troubleshooting: Filesystem Violations](docs/troubleshooting/filesystem-violations.md)
+- [Examples: Filesystem Isolation](docs/examples/filesystem-isolation.md)
+- [ADR-002: Filesystem Isolation Architecture](docs/architecture/adr-002-filesystem-isolation.md)
 
 ## Project Resources
 

--- a/docs/examples/filesystem-isolation.md
+++ b/docs/examples/filesystem-isolation.md
@@ -1,0 +1,705 @@
+# Filesystem Isolation Examples
+
+> **PLANNED FEATURE - Coming in v0.5.0**
+>
+> These examples demonstrate the **expected behavior** once filesystem isolation is fully released.
+> The design is documented in [ADR-002](../architecture/adr-002-filesystem-isolation.md).
+> The error messages, CLI options, and markers shown below are **not yet available**.
+>
+> Track progress: [Epic #66](https://github.com/mikelane/pytest-test-categories/issues/66)
+
+## Prerequisites
+
+To follow these examples when the feature is released, you may want to install optional mocking libraries:
+
+```bash
+# For comprehensive filesystem mocking
+pip install pyfakefs
+
+# For general mocking (usually already included with pytest)
+pip install pytest-mock
+```
+
+These libraries are **not required** by pytest-test-categories but are recommended for writing
+hermetic tests that mock filesystem operations.
+
+---
+
+This document provides practical examples of tests that violate filesystem isolation and how to fix them.
+
+## Example 1: Writing Report Files
+
+### Violating Test
+
+This test writes a file directly to the project directory, violating small test requirements:
+
+```python
+# tests/test_reports.py
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.small
+def test_generate_report():
+    """Generate a report file."""
+    report_path = Path("output/report.txt")
+    report_path.parent.mkdir(exist_ok=True)
+    report_path.write_text("Test Report\n==========\nAll tests passed.")
+
+    assert report_path.exists()
+    assert "All tests passed" in report_path.read_text()
+```
+
+**Error:**
+
+```
+HermeticityViolationError: Filesystem access attempted
+Attempted create on: /home/user/project/output/
+```
+
+### Fixed Test Using tmp_path
+
+```python
+# tests/test_reports.py
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.small
+def test_generate_report(tmp_path):
+    """Generate a report file using pytest's tmp_path fixture."""
+    # Arrange: Create output directory in temp space
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    report_path = output_dir / "report.txt"
+
+    # Act: Generate the report
+    report_path.write_text("Test Report\n==========\nAll tests passed.")
+
+    # Assert: Verify the report was created correctly
+    assert report_path.exists()
+    assert "All tests passed" in report_path.read_text()
+```
+
+### Fixed Test Using StringIO
+
+```python
+# tests/test_reports.py
+from io import StringIO
+
+import pytest
+
+
+@pytest.mark.small
+def test_generate_report_content():
+    """Generate report content without filesystem access."""
+    # Arrange: Create an in-memory buffer
+    buffer = StringIO()
+
+    # Act: Generate the report to the buffer
+    generate_report(buffer)
+
+    # Assert: Verify the report content
+    content = buffer.getvalue()
+    assert "Test Report" in content
+    assert "All tests passed" in content
+```
+
+## Example 2: Reading Configuration Files
+
+### Violating Test
+
+This test reads a real configuration file:
+
+```python
+# tests/test_config.py
+from pathlib import Path
+
+import pytest
+
+from myapp.config import load_config
+
+
+@pytest.mark.small
+def test_load_config():
+    """Load configuration from file."""
+    config = load_config(Path("/etc/myapp/config.yaml"))
+
+    assert config["database"]["host"] == "localhost"
+    assert config["database"]["port"] == 5432
+```
+
+**Error:**
+
+```
+HermeticityViolationError: Filesystem access attempted
+Attempted read on: /etc/myapp/config.yaml
+```
+
+### Fixed Test Using Mock
+
+```python
+# tests/test_config.py
+import pytest
+
+from myapp.config import load_config
+
+
+CONFIG_YAML = """
+database:
+  host: localhost
+  port: 5432
+  name: myapp_db
+"""
+
+
+@pytest.mark.small
+def test_load_config_parses_yaml(mocker):
+    """Load configuration from mocked file."""
+    # Arrange: Mock the file open operation
+    mocker.patch("builtins.open", mocker.mock_open(read_data=CONFIG_YAML))
+
+    # Act: Load the configuration
+    config = load_config("/etc/myapp/config.yaml")
+
+    # Assert: Verify the configuration was parsed correctly
+    assert config["database"]["host"] == "localhost"
+    assert config["database"]["port"] == 5432
+```
+
+### Fixed Test Using tmp_path
+
+```python
+# tests/test_config.py
+from pathlib import Path
+
+import pytest
+
+from myapp.config import load_config
+
+
+CONFIG_YAML = """
+database:
+  host: localhost
+  port: 5432
+  name: myapp_db
+"""
+
+
+@pytest.mark.small
+def test_load_config_from_file(tmp_path):
+    """Load configuration from a real file in temp space."""
+    # Arrange: Create config file in temp directory
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(CONFIG_YAML)
+
+    # Act: Load the configuration
+    config = load_config(config_file)
+
+    # Assert: Verify the configuration
+    assert config["database"]["host"] == "localhost"
+    assert config["database"]["port"] == 5432
+```
+
+### Fixed Test Using Dependency Injection
+
+```python
+# src/myapp/config.py
+from io import StringIO
+from pathlib import Path
+from typing import TextIO
+
+import yaml
+
+
+def load_config(source: Path | TextIO) -> dict:
+    """Load configuration from a file path or file-like object.
+
+    Args:
+        source: Either a Path to a config file, or a file-like object.
+
+    Returns:
+        Configuration dictionary.
+
+    """
+    if isinstance(source, Path):
+        with open(source) as f:
+            return yaml.safe_load(f)
+    else:
+        return yaml.safe_load(source)
+```
+
+```python
+# tests/test_config.py
+from io import StringIO
+
+import pytest
+
+from myapp.config import load_config
+
+
+CONFIG_YAML = """
+database:
+  host: localhost
+  port: 5432
+"""
+
+
+@pytest.mark.small
+def test_load_config_from_stream():
+    """Load configuration from a stream (no filesystem access)."""
+    # Arrange: Create config as StringIO
+    config_stream = StringIO(CONFIG_YAML)
+
+    # Act: Load from stream
+    config = load_config(config_stream)
+
+    # Assert: Verify configuration
+    assert config["database"]["host"] == "localhost"
+```
+
+## Example 3: File Processing Pipeline
+
+### Violating Test
+
+This test processes files from the project directory:
+
+```python
+# tests/test_processor.py
+from pathlib import Path
+
+import pytest
+
+from myapp.processor import process_data_files
+
+
+@pytest.mark.small
+def test_process_data_files():
+    """Process all data files in a directory."""
+    data_dir = Path("data/input")
+    output_dir = Path("data/output")
+
+    results = process_data_files(data_dir, output_dir)
+
+    assert len(results) > 0
+    assert all(r.success for r in results)
+```
+
+**Error:**
+
+```
+HermeticityViolationError: Filesystem access attempted
+Attempted list on: /home/user/project/data/input/
+```
+
+### Fixed Test Using tmp_path
+
+```python
+# tests/test_processor.py
+from pathlib import Path
+
+import pytest
+
+from myapp.processor import process_data_files
+
+
+@pytest.mark.small
+def test_process_data_files(tmp_path):
+    """Process all data files in a directory."""
+    # Arrange: Create test directory structure
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    # Create test data files
+    (input_dir / "file1.csv").write_text("id,name\n1,Alice\n2,Bob")
+    (input_dir / "file2.csv").write_text("id,name\n3,Charlie")
+
+    # Act: Process the files
+    results = process_data_files(input_dir, output_dir)
+
+    # Assert: Verify processing results
+    assert len(results) == 2
+    assert all(r.success for r in results)
+    assert (output_dir / "file1_processed.csv").exists()
+    assert (output_dir / "file2_processed.csv").exists()
+```
+
+### Fixed Test Using pyfakefs
+
+```python
+# tests/test_processor.py
+import pytest
+
+from myapp.processor import process_data_files
+
+
+@pytest.mark.small
+def test_process_data_files_with_fake_fs(fs):
+    """Process data files using a fake filesystem."""
+    # Arrange: Create fake directory structure
+    fs.create_dir("/data/input")
+    fs.create_dir("/data/output")
+    fs.create_file("/data/input/file1.csv", contents="id,name\n1,Alice\n2,Bob")
+    fs.create_file("/data/input/file2.csv", contents="id,name\n3,Charlie")
+
+    # Act: Process the files
+    results = process_data_files("/data/input", "/data/output")
+
+    # Assert: Verify processing
+    assert len(results) == 2
+    assert all(r.success for r in results)
+```
+
+## Example 4: Log File Testing
+
+### Violating Test
+
+This test checks log file creation:
+
+```python
+# tests/test_logging.py
+from pathlib import Path
+
+import pytest
+
+from myapp.logging import setup_logging, get_logger
+
+
+@pytest.mark.small
+def test_logging_creates_file():
+    """Logging creates a log file."""
+    log_dir = Path("logs")
+    setup_logging(log_dir)
+    logger = get_logger("test")
+
+    logger.info("Test message")
+
+    log_file = log_dir / "app.log"
+    assert log_file.exists()
+    assert "Test message" in log_file.read_text()
+```
+
+**Error:**
+
+```
+HermeticityViolationError: Filesystem access attempted
+Attempted create on: /home/user/project/logs/
+```
+
+### Fixed Test Using tmp_path
+
+```python
+# tests/test_logging.py
+from pathlib import Path
+
+import pytest
+
+from myapp.logging import setup_logging, get_logger
+
+
+@pytest.mark.small
+def test_logging_creates_file(tmp_path):
+    """Logging creates a log file in temp directory."""
+    # Arrange: Set up logging in temp directory
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    setup_logging(log_dir)
+    logger = get_logger("test")
+
+    # Act: Write a log message
+    logger.info("Test message")
+
+    # Assert: Verify the log file
+    log_file = log_dir / "app.log"
+    assert log_file.exists()
+    assert "Test message" in log_file.read_text()
+```
+
+### Fixed Test Using StringIO Handler
+
+```python
+# tests/test_logging.py
+import logging
+from io import StringIO
+
+import pytest
+
+from myapp.logging import get_logger
+
+
+@pytest.mark.small
+def test_logging_output():
+    """Logging outputs correct messages (no file access)."""
+    # Arrange: Create a StringIO handler
+    log_stream = StringIO()
+    handler = logging.StreamHandler(log_stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    logger = get_logger("test")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    # Act: Write a log message
+    logger.info("Test message")
+
+    # Assert: Verify the log output
+    log_content = log_stream.getvalue()
+    assert "Test message" in log_content
+```
+
+## Example 5: Database Fixture Files
+
+### Violating Test
+
+This test loads SQL fixtures from the repository:
+
+```python
+# tests/test_database.py
+from pathlib import Path
+
+import pytest
+
+from myapp.database import execute_sql
+
+
+@pytest.mark.small
+def test_create_tables(mocker):
+    """Create database tables from SQL file."""
+    mock_conn = mocker.Mock()
+    sql_file = Path("tests/fixtures/schema.sql")
+
+    execute_sql(mock_conn, sql_file.read_text())
+
+    mock_conn.execute.assert_called()
+```
+
+**Error:**
+
+```
+HermeticityViolationError: Filesystem access attempted
+Attempted read on: /home/user/project/tests/fixtures/schema.sql
+```
+
+### Fixed Test With Embedded SQL
+
+```python
+# tests/test_database.py
+import pytest
+
+from myapp.database import execute_sql
+
+
+SCHEMA_SQL = """
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    total DECIMAL(10, 2)
+);
+"""
+
+
+@pytest.mark.small
+def test_create_tables(mocker):
+    """Create database tables from SQL."""
+    # Arrange: Create mock connection
+    mock_conn = mocker.Mock()
+
+    # Act: Execute the schema SQL
+    execute_sql(mock_conn, SCHEMA_SQL)
+
+    # Assert: Verify SQL was executed
+    assert mock_conn.execute.called
+    # Verify CREATE TABLE was in the executed SQL
+    executed_sql = mock_conn.execute.call_args[0][0]
+    assert "CREATE TABLE users" in executed_sql
+```
+
+### Fixed Test With Allowed Fixtures Path
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+test_categories_allowed_paths = ["tests/fixtures/"]
+```
+
+```python
+# tests/test_database.py
+from pathlib import Path
+
+import pytest
+
+from myapp.database import execute_sql
+
+
+@pytest.mark.small
+def test_create_tables(mocker):
+    """Create database tables from SQL file (fixture path allowed)."""
+    mock_conn = mocker.Mock()
+    # This path is now allowed via configuration
+    sql_file = Path("tests/fixtures/schema.sql")
+
+    execute_sql(mock_conn, sql_file.read_text())
+
+    mock_conn.execute.assert_called()
+```
+
+## Example 6: Using Medium Test Size
+
+Sometimes filesystem access is genuinely required. In these cases, use a medium test:
+
+### Legitimate Filesystem Test
+
+```python
+# tests/integration/test_file_io.py
+from pathlib import Path
+
+import pytest
+
+from myapp.file_io import safe_write, atomic_replace
+
+
+@pytest.mark.medium  # Medium tests can access the filesystem
+def test_atomic_file_replacement(tmp_path):
+    """Test atomic file replacement with real filesystem."""
+    # Arrange: Create original file
+    target = tmp_path / "config.json"
+    target.write_text('{"version": 1}')
+
+    # Act: Atomically replace the file
+    atomic_replace(target, '{"version": 2}')
+
+    # Assert: File was updated atomically
+    assert target.read_text() == '{"version": 2}'
+
+
+@pytest.mark.medium
+def test_safe_write_creates_backup(tmp_path):
+    """Test safe write creates backup file."""
+    # Arrange: Create original file
+    target = tmp_path / "data.txt"
+    target.write_text("original content")
+
+    # Act: Safe write with backup
+    safe_write(target, "new content", backup=True)
+
+    # Assert: Backup was created
+    backup = tmp_path / "data.txt.bak"
+    assert backup.exists()
+    assert backup.read_text() == "original content"
+    assert target.read_text() == "new content"
+```
+
+## Configuration Examples
+
+### pyproject.toml
+
+```toml
+[tool.pytest.ini_options]
+# Markers for test sizes
+markers = [
+    "small: Fast, hermetic unit tests (< 1s)",
+    "medium: Integration tests with local services (< 5min)",
+    "large: End-to-end tests (< 15min)",
+    "xlarge: Extended tests (< 15min)",
+    "allow_filesystem: Override filesystem blocking for specific test",
+]
+
+# Enable strict filesystem and network isolation
+test_categories_enforcement = "strict"
+
+# Allow reading from test fixtures directory
+test_categories_allowed_paths = [
+    "tests/fixtures/",
+    "tests/data/",
+]
+```
+
+### pytest.ini
+
+```ini
+[pytest]
+markers =
+    small: Fast, hermetic unit tests (< 1s)
+    medium: Integration tests with local services (< 5min)
+    large: End-to-end tests (< 15min)
+    xlarge: Extended tests (< 15min)
+    allow_filesystem: Override filesystem blocking for specific test
+
+test_categories_enforcement = strict
+test_categories_allowed_paths = tests/fixtures/,tests/data/
+```
+
+### CI Pipeline Example
+
+```yaml
+# .github/workflows/test.yml
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv sync --all-groups
+
+      - name: Run tests with filesystem isolation
+        run: |
+          uv run pytest --test-categories-enforcement=strict
+```
+
+### Gradual Migration Example
+
+```yaml
+# .github/workflows/test.yml
+jobs:
+  # Warn about violations but don't fail
+  test-with-warnings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests (warn mode)
+        run: |
+          uv run pytest --test-categories-enforcement=warn 2>&1 | tee test-output.txt
+          grep "Filesystem access violation" test-output.txt > violations.txt || true
+          if [ -s violations.txt ]; then
+            echo "::warning::Filesystem violations detected (see violations.txt)"
+            cat violations.txt
+          fi
+
+  # Strict enforcement on main branch
+  test-strict:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests (strict mode)
+        run: |
+          uv run pytest --test-categories-enforcement=strict
+```
+
+## Related Documentation
+
+- [User Guide: Filesystem Isolation](../user-guide/filesystem-isolation.md)
+- [Troubleshooting: Filesystem Violations](../troubleshooting/filesystem-violations.md)
+- [ADR-002: Filesystem Isolation](../architecture/adr-002-filesystem-isolation.md)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -8,6 +8,7 @@ This section provides practical examples of using pytest-test-categories in vari
 :maxdepth: 2
 
 network-isolation
+filesystem-isolation
 ```
 
 ## Quick Examples

--- a/docs/troubleshooting/filesystem-violations.md
+++ b/docs/troubleshooting/filesystem-violations.md
@@ -1,0 +1,537 @@
+# Troubleshooting Filesystem Violations
+
+> **PLANNED FEATURE - Coming in v0.5.0**
+>
+> This troubleshooting guide describes error messages and behaviors that will be available
+> once filesystem isolation is fully released. The design is documented in
+> [ADR-002](../architecture/adr-002-filesystem-isolation.md).
+>
+> Track progress: [Epic #66](https://github.com/mikelane/pytest-test-categories/issues/66)
+
+This guide helps you identify and fix filesystem access violations in your test suite.
+
+## Understanding the Error Message
+
+When a filesystem violation occurs in strict mode, you see an error like this:
+
+```
+============================================================
+HermeticityViolationError
+============================================================
+Test: tests/test_reports.py::test_save_report
+Category: SMALL
+Violation: Filesystem access attempted
+
+Details:
+  Attempted write on: /home/user/project/output/report.txt
+
+Small tests have restricted resource access. Options:
+  1. Use pytest's tmp_path fixture for temporary files
+  2. Mock file operations using pytest-mock (mocker fixture) or pyfakefs
+  3. Use io.StringIO or io.BytesIO for in-memory file-like objects
+  4. Embed test data as Python constants or use importlib.resources
+  5. Change test category to @pytest.mark.medium (if filesystem access is required)
+
+Documentation: See docs/architecture/adr-002-filesystem-isolation.md
+============================================================
+```
+
+The error tells you:
+
+- **Test**: The full pytest node ID of the failing test
+- **Category**: The test size (SMALL, MEDIUM, etc.)
+- **Details**: The operation type and path that the test attempted to access
+- **Options**: Suggested fixes for the violation
+
+## Common Violation Scenarios
+
+### 1. Writing Output Files
+
+**Symptom**: Write operation on a path outside allowed directories.
+
+```
+Attempted write on: /home/user/project/output/report.txt
+```
+
+**Cause**: Test code writes files directly to the project directory:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_generate_report():
+    output = Path("output/report.txt")
+    output.write_text("Report content")
+    assert output.exists()
+```
+
+**Fix**: Use pytest's `tmp_path` fixture:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_generate_report(tmp_path):
+    output = tmp_path / "report.txt"
+    output.write_text("Report content")
+    assert output.exists()
+    assert output.read_text() == "Report content"
+```
+
+### 2. Reading Configuration Files
+
+**Symptom**: Read operation on a configuration file path.
+
+```
+Attempted read on: /etc/myapp/config.ini
+```
+
+**Cause**: Test reads a real configuration file:
+
+```python
+@pytest.mark.small
+def test_load_config():
+    config = load_config("/etc/myapp/config.ini")
+    assert config["database"]["host"] == "localhost"
+```
+
+**Fix**: Use a mock or StringIO:
+
+```python
+from io import StringIO
+
+CONFIG_CONTENT = """
+[database]
+host = localhost
+port = 5432
+"""
+
+@pytest.mark.small
+def test_load_config():
+    config = load_config_from_stream(StringIO(CONFIG_CONTENT))
+    assert config["database"]["host"] == "localhost"
+```
+
+Or use pytest-mock:
+
+```python
+@pytest.mark.small
+def test_load_config(mocker):
+    config_content = "[database]\nhost = localhost\nport = 5432"
+    mocker.patch("builtins.open", mocker.mock_open(read_data=config_content))
+
+    config = load_config("/etc/myapp/config.ini")
+
+    assert config["database"]["host"] == "localhost"
+```
+
+### 3. Creating Directories
+
+**Symptom**: Create operation on a directory path.
+
+```
+Attempted create on: /home/user/project/logs/
+```
+
+**Cause**: Test creates directories in the project:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_setup_logging():
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+    setup_logging(log_dir)
+```
+
+**Fix**: Use tmp_path:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_setup_logging(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    setup_logging(log_dir)
+    assert (log_dir / "app.log").exists()
+```
+
+### 4. Checking File Existence
+
+**Symptom**: Stat operation on a non-allowed path.
+
+```
+Attempted stat on: /home/user/project/data/users.json
+```
+
+**Cause**: Test checks if a file exists outside allowed paths:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_data_file_exists():
+    data_file = Path("data/users.json")
+    assert data_file.exists()
+```
+
+**Fix**: If the test is verifying behavior, mock the existence check:
+
+```python
+@pytest.mark.small
+def test_handles_missing_file(mocker):
+    mocker.patch("pathlib.Path.exists", return_value=False)
+
+    result = load_data_with_fallback("data/users.json")
+
+    assert result == []  # Falls back to empty list
+```
+
+Or create the file in tmp_path:
+
+```python
+@pytest.mark.small
+def test_data_file_loaded(tmp_path):
+    data_file = tmp_path / "users.json"
+    data_file.write_text('[{"name": "Alice"}]')
+
+    result = load_data(data_file)
+
+    assert result[0]["name"] == "Alice"
+```
+
+### 5. Reading Test Fixtures
+
+**Symptom**: Read operation on fixture files.
+
+```
+Attempted read on: /home/user/project/tests/fixtures/sample.xml
+```
+
+**Cause**: Test reads fixture files from the repository:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_parse_xml():
+    fixture = Path("tests/fixtures/sample.xml")
+    result = parse_xml(fixture.read_text())
+    assert result.root.tag == "document"
+```
+
+**Fix Option 1**: Add fixture directory to allowed paths:
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+test_categories_allowed_paths = ["tests/fixtures/"]
+```
+
+**Fix Option 2**: Embed fixture data in the test:
+
+```python
+SAMPLE_XML = """
+<?xml version="1.0"?>
+<document>
+  <title>Test Document</title>
+</document>
+"""
+
+@pytest.mark.small
+def test_parse_xml():
+    result = parse_xml(SAMPLE_XML)
+    assert result.root.tag == "document"
+```
+
+**Fix Option 3**: Use importlib.resources for package fixtures:
+
+```python
+from importlib import resources
+
+@pytest.mark.small
+def test_parse_xml():
+    sample_xml = resources.read_text("tests.fixtures", "sample.xml")
+    result = parse_xml(sample_xml)
+    assert result.root.tag == "document"
+```
+
+### 6. Deleting Files
+
+**Symptom**: Delete operation on a non-allowed path.
+
+```
+Attempted delete on: /home/user/project/temp/cache.db
+```
+
+**Cause**: Test cleans up files outside allowed directories:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_clear_cache():
+    cache_file = Path("temp/cache.db")
+    cache_file.unlink(missing_ok=True)
+    assert not cache_file.exists()
+```
+
+**Fix**: Use tmp_path for the cache:
+
+```python
+@pytest.mark.small
+def test_clear_cache(tmp_path):
+    cache_file = tmp_path / "cache.db"
+    cache_file.write_bytes(b"cached data")
+
+    clear_cache(cache_file)
+
+    assert not cache_file.exists()
+```
+
+### 7. Listing Directory Contents
+
+**Symptom**: List operation on a non-allowed path.
+
+```
+Attempted list on: /home/user/project/plugins/
+```
+
+**Cause**: Test lists files in a project directory:
+
+```python
+from pathlib import Path
+
+@pytest.mark.small
+def test_discover_plugins():
+    plugin_dir = Path("plugins")
+    plugins = list(plugin_dir.glob("*.py"))
+    assert len(plugins) > 0
+```
+
+**Fix**: Create test plugins in tmp_path:
+
+```python
+@pytest.mark.small
+def test_discover_plugins(tmp_path):
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin_a.py").write_text("# Plugin A")
+    (plugin_dir / "plugin_b.py").write_text("# Plugin B")
+
+    plugins = discover_plugins(plugin_dir)
+
+    assert len(plugins) == 2
+```
+
+## Identifying Filesystem-Calling Code
+
+### Step 1: Run Tests in Warn Mode
+
+First, identify all violations without failing tests:
+
+```bash
+pytest --test-categories-enforcement=warn 2>&1 | grep -A3 "Filesystem access violation"
+```
+
+### Step 2: Add Debugging Output
+
+If the source is unclear, add filesystem debugging:
+
+```python
+import builtins
+
+# Temporarily patch to see call stack
+original_open = builtins.open
+
+def debug_open(file, *args, **kwargs):
+    import traceback
+    print(f"File open attempt: {file}")
+    traceback.print_stack()
+    return original_open(file, *args, **kwargs)
+
+builtins.open = debug_open
+```
+
+### Step 3: Use pytest Verbose Mode
+
+Run the specific test with verbose output:
+
+```bash
+pytest tests/test_reports.py::test_save_report -vvs
+```
+
+### Step 4: Check Fixture Dependencies
+
+Filesystem access often happens in fixtures:
+
+```python
+@pytest.fixture
+def config():
+    # This fixture reads a real file!
+    with open("config.yaml") as f:
+        return yaml.safe_load(f)
+```
+
+Review all fixtures used by the failing test.
+
+### Step 5: Check Module-Level Code
+
+Filesystem access may happen at import time:
+
+```python
+# src/myapp/settings.py
+from pathlib import Path
+
+# This runs when the module is imported!
+CONFIG_PATH = Path("/etc/myapp/config.ini")
+if CONFIG_PATH.exists():  # <-- Filesystem access during import
+    DEFAULT_CONFIG = CONFIG_PATH.read_text()
+```
+
+Consider deferring such access or using lazy initialization.
+
+## Migration Guide
+
+### Phase 1: Assessment
+
+1. Enable warn mode in CI:
+
+   ```toml
+   [tool.pytest.ini_options]
+   test_categories_enforcement = "warn"
+   ```
+
+2. Collect all warnings from a full test run
+3. Categorize violations by type (read, write, fixture, etc.)
+4. Estimate effort to fix each category
+
+### Phase 2: Quick Wins
+
+1. Add commonly-used fixture directories to allowed paths
+2. Replace hardcoded paths with tmp_path fixture
+3. Convert string literals to StringIO/BytesIO
+4. Add missing `tmp_path` fixture parameters
+
+### Phase 3: Refactoring
+
+1. Introduce dependency injection for file operations
+2. Create abstraction layers for filesystem access
+3. Build test fixtures that create needed files in tmp_path
+4. Move test data into embedded constants or package resources
+
+### Phase 4: Enforcement
+
+1. Switch to strict mode in CI:
+
+   ```toml
+   [tool.pytest.ini_options]
+   test_categories_enforcement = "strict"
+   ```
+
+2. Add pre-commit hook to catch violations locally
+3. Document filesystem mocking patterns for the team
+4. Update test templates to use tmp_path by default
+
+## Debugging Access Patterns
+
+### Using strace/dtruss (Linux/macOS)
+
+For deep debugging, trace system calls:
+
+```bash
+# Linux
+strace -e openat,stat,unlink -f python -m pytest tests/test_reports.py::test_save_report
+
+# macOS
+sudo dtruss -f -t open python -m pytest tests/test_reports.py::test_save_report
+```
+
+### Using Python's Audit Hooks
+
+Python 3.8+ supports audit hooks for monitoring:
+
+```python
+import sys
+
+def audit_hook(event, args):
+    if event.startswith("open"):
+        print(f"Audit: {event} {args}")
+
+sys.addaudithook(audit_hook)
+```
+
+### Using Coverage with Branch Tracking
+
+Run coverage to see which code paths access files:
+
+```bash
+coverage run --branch -m pytest tests/test_reports.py::test_save_report
+coverage report --show-missing
+```
+
+## Temporary Workarounds
+
+### Allow Filesystem for Specific Test
+
+If you cannot immediately fix a test, use the `allow_filesystem` marker (when available):
+
+```python
+@pytest.mark.small
+@pytest.mark.allow_filesystem  # TODO: Remove after fixing #123
+def test_legacy_file_operation():
+    """Temporary workaround until mocking is implemented."""
+    ...
+```
+
+Always add a TODO comment and track the technical debt.
+
+### Skip in CI Only
+
+For tests that work locally but fail in CI due to filesystem restrictions:
+
+```python
+import os
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="Filesystem access blocked in CI"
+)
+@pytest.mark.small
+def test_requires_filesystem():
+    ...
+```
+
+This is a temporary measure - fix the underlying issue.
+
+### Change Test Size Temporarily
+
+As a last resort, change the test size:
+
+```python
+@pytest.mark.medium  # TODO: Refactor to small test (issue #123)
+def test_config_loading():
+    """Currently reads real config file. Should use mock."""
+    ...
+```
+
+Document the technical debt and create a tracking issue.
+
+## Getting Help
+
+If you encounter a violation you cannot resolve:
+
+1. Check the [examples documentation](../examples/filesystem-isolation.md)
+2. Review the [ADR for filesystem isolation](../architecture/adr-002-filesystem-isolation.md)
+3. Open a [GitHub Discussion](https://github.com/mikelane/pytest-test-categories/discussions) with:
+   - The full error message
+   - The test code (sanitized if needed)
+   - What you have tried
+
+## Related Documentation
+
+- [User Guide: Filesystem Isolation](../user-guide/filesystem-isolation.md)
+- [Examples: Filesystem Isolation](../examples/filesystem-isolation.md)
+- [ADR-002: Filesystem Isolation](../architecture/adr-002-filesystem-isolation.md)

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -8,6 +8,7 @@ This section helps you diagnose and fix common issues with pytest-test-categorie
 :maxdepth: 2
 
 network-violations
+filesystem-violations
 ```
 
 ## Common Issues

--- a/docs/user-guide/filesystem-isolation.md
+++ b/docs/user-guide/filesystem-isolation.md
@@ -1,0 +1,469 @@
+# Filesystem Isolation for Hermetic Tests
+
+> **PLANNED FEATURE - Coming in v0.5.0**
+>
+> This documentation describes filesystem isolation features that are **currently being implemented**.
+> The design is documented in [ADR-002](../architecture/adr-002-filesystem-isolation.md).
+> Implementation will follow in Issues #92 (port interface), #93 (adapters), and #95 (pytest integration).
+>
+> Track progress: [Epic #66](https://github.com/mikelane/pytest-test-categories/issues/66)
+
+## What is Filesystem Isolation?
+
+Filesystem isolation is a test enforcement mechanism that prevents small tests from accessing the filesystem during execution. This ensures tests are **hermetic** - running entirely in memory with no external dependencies.
+
+When enabled, the pytest-test-categories plugin intercepts filesystem operations and either blocks them or warns about them, depending on your configuration.
+
+## Why Filesystem Isolation Matters
+
+Tests that access the filesystem introduce several problems:
+
+### Side Effects
+
+Filesystem-dependent tests create unpredictable side effects:
+
+- Files created by one test may persist and affect subsequent tests
+- Tests may overwrite or delete files needed by other tests
+- Parallel test execution leads to race conditions on shared files
+- CI environments may have different filesystem layouts than local development
+
+### State Leakage
+
+External filesystem state makes tests non-deterministic:
+
+- Tests depend on specific files existing at specific paths
+- Configuration files vary between environments
+- Data files may change between test runs
+- Paths are often platform-specific (Windows vs. Unix)
+
+### Slow Tests
+
+Disk I/O adds latency that compounds across your test suite:
+
+- File operations are orders of magnitude slower than memory operations
+- SSDs are fast but still 1000x slower than RAM
+- Network filesystems (NFS, CIFS) add significant latency
+- Disk contention increases as tests run in parallel
+
+### Non-Hermeticity
+
+Tests that read or write external files are not self-contained:
+
+- Cannot run reliably in isolated CI containers
+- May fail when paths differ between developers
+- Difficult to parallelize safely
+- Hard to reproduce failures
+
+## Google's Test Size Definitions
+
+The filesystem isolation feature implements Google's test size definitions from "Software Engineering at Google":
+
+| Test Size | Filesystem Access | Rationale |
+|-----------|------------------|-----------|
+| Small     | **Blocked** (except allowed paths) | Must be hermetic, run in memory only |
+| Medium    | Allowed          | May use local filesystem for integration tests |
+| Large     | Allowed          | Integration tests may access real filesystems |
+| XLarge    | Allowed          | End-to-end tests may access real filesystems |
+
+### Small Tests
+
+Small tests are the foundation of a healthy test suite. They must be:
+
+- **Fast**: Complete in under 1 second
+- **Hermetic**: No external dependencies
+- **Deterministic**: Same input always produces same output
+- **Parallelizable**: Safe to run concurrently with other tests
+
+Filesystem isolation enforces hermeticity by blocking filesystem access in small tests, except for explicitly allowed paths.
+
+### Medium, Large, and XLarge Tests
+
+Medium, large, and XLarge tests may access the filesystem freely, enabling:
+
+- File-based integration tests
+- Configuration file parsing tests
+- Log file generation tests
+- Data import/export tests
+
+## How It Works
+
+The plugin intercepts filesystem operations by patching Python's built-in functions and modules:
+
+### Patched Entry Points
+
+The following filesystem entry points are intercepted:
+
+- `builtins.open` - Primary file open function
+- `io.open` - Alias for built-in open
+- `pathlib.Path.open` - pathlib file access
+- `pathlib.Path.read_text`, `Path.read_bytes` - Direct read methods
+- `pathlib.Path.write_text`, `Path.write_bytes` - Direct write methods
+- `os.open`, `os.mkdir`, `os.remove`, etc. - Low-level operations
+
+### Operation Categories
+
+Filesystem operations are categorized as:
+
+| Operation | Description | Examples |
+|-----------|-------------|----------|
+| READ | Read file contents | `open()` for reading, `Path.read_text()` |
+| WRITE | Write file contents | `open()` for writing, `Path.write_text()` |
+| CREATE | Create files/directories | `mkdir()`, `touch()`, `open('x')` |
+| DELETE | Remove files/directories | `os.remove()`, `Path.unlink()`, `shutil.rmtree()` |
+| MODIFY | Change file attributes | `chmod()`, `chown()`, `rename()` |
+| STAT | Read file metadata | `stat()`, `exists()`, `is_file()` |
+| LIST | List directory contents | `listdir()`, `scandir()`, `iterdir()` |
+
+All operations are blocked on non-allowed paths for small tests, including STAT operations. This ensures tests do not depend on external filesystem state.
+
+## Default Allowed Paths
+
+Certain paths are automatically allowed, even for small tests:
+
+### System Temp Directory
+
+The system temporary directory (`tempfile.gettempdir()`) and all its subdirectories are allowed. This includes:
+
+- `/tmp` on Linux/macOS
+- `C:\Users\<user>\AppData\Local\Temp` on Windows
+
+### pytest's basetemp Directory
+
+The pytest `tmp_path` fixture creates directories under pytest's basetemp. These are automatically allowed:
+
+- Default location: `{tempdir}/pytest-of-{username}/`
+- Custom location: Set via `--basetemp` CLI option
+
+### pytest Fixture Paths
+
+When your test uses `tmp_path` or `tmp_path_factory` fixtures, those paths are automatically added to the allowed list for that specific test.
+
+```python
+@pytest.mark.small
+def test_with_temp_file(tmp_path):
+    # tmp_path is automatically allowed
+    test_file = tmp_path / "data.txt"
+    test_file.write_text("hello")  # OK - under tmp_path
+    assert test_file.read_text() == "hello"
+```
+
+## Enabling Filesystem Isolation
+
+Filesystem isolation is controlled by the `test_categories_enforcement` configuration option, the same option used for network isolation.
+
+### Configuration via pyproject.toml
+
+```toml
+[tool.pytest.ini_options]
+# Enable filesystem and network isolation enforcement
+test_categories_enforcement = "strict"
+```
+
+### Configuration via pytest.ini
+
+```ini
+[pytest]
+test_categories_enforcement = strict
+```
+
+### Configuration via Command Line
+
+```bash
+pytest --test-categories-enforcement=strict
+```
+
+## Enforcement Modes
+
+The plugin supports three enforcement modes:
+
+### STRICT Mode
+
+```toml
+test_categories_enforcement = "strict"
+```
+
+In strict mode, filesystem violations immediately fail the test with a detailed error message:
+
+```
+============================================================
+HermeticityViolationError
+============================================================
+Test: tests/test_reports.py::test_save_report
+Category: SMALL
+Violation: Filesystem access attempted
+
+Details:
+  Attempted write on: /home/user/project/output/report.txt
+
+Small tests have restricted resource access. Options:
+  1. Use pytest's tmp_path fixture for temporary files
+  2. Mock file operations using pytest-mock (mocker fixture) or pyfakefs
+  3. Use io.StringIO or io.BytesIO for in-memory file-like objects
+  4. Embed test data as Python constants or use importlib.resources
+  5. Change test category to @pytest.mark.medium (if filesystem access is required)
+
+Documentation: See docs/architecture/adr-002-filesystem-isolation.md
+============================================================
+```
+
+Use strict mode in CI pipelines to catch violations before merge.
+
+### WARN Mode
+
+```toml
+test_categories_enforcement = "warn"
+```
+
+In warn mode, filesystem violations emit a warning but allow the test to continue:
+
+```
+PytestWarning: Filesystem access violation in test_save_report:
+attempted write on /home/user/project/output/report.txt
+```
+
+Use warn mode during migration to identify violations without breaking the build.
+
+### OFF Mode
+
+```toml
+test_categories_enforcement = "off"
+```
+
+In off mode, filesystem isolation is disabled entirely. Use this for:
+
+- Legacy test suites not yet ready for enforcement
+- Specific test runs that require filesystem access
+- Debugging filesystem-related test issues
+
+## Adding Custom Allowed Paths
+
+You can configure additional paths that are always allowed for small tests.
+
+### Configuration via pyproject.toml
+
+```toml
+[tool.pytest.ini_options]
+test_categories_enforcement = "strict"
+
+# Additional allowed paths for filesystem access
+test_categories_allowed_paths = [
+    "tests/fixtures/",
+    "src/mypackage/data/",
+]
+```
+
+### Configuration via Command Line
+
+```bash
+pytest --test-categories-allowed-paths=tests/fixtures/,src/mypackage/data/
+```
+
+Paths can be:
+- Absolute paths: `/home/user/project/fixtures/`
+- Relative paths: `tests/fixtures/` (resolved from project root)
+- User-relative paths: `~/project/data/` (expanded with `~`)
+
+## Per-Test Overrides
+
+> **Planned Markers** - The markers below are not yet implemented.
+
+Individual tests can override the global enforcement using markers:
+
+### Allow All Filesystem Access
+
+```python
+@pytest.mark.small
+@pytest.mark.allow_filesystem  # Planned - not yet available
+def test_special_case():
+    """This small test is allowed to access the filesystem."""
+    # Filesystem access is permitted for this test only
+    ...
+```
+
+### Allow Specific Paths
+
+```python
+@pytest.mark.small
+@pytest.mark.allow_filesystem_paths('/specific/path')  # Planned - not yet available
+def test_with_fixture_file():
+    """This small test can access a specific path."""
+    ...
+```
+
+Use these markers sparingly and document why the override is necessary.
+
+## Understanding Error Messages
+
+When a filesystem violation occurs, the error message provides:
+
+1. **Test identification**: The full pytest node ID
+2. **Category**: The test size (SMALL, MEDIUM, etc.)
+3. **Operation**: The type of operation attempted (read, write, etc.)
+4. **Path**: The path that was accessed
+5. **Remediation options**: Specific suggestions for fixing the violation
+
+### Example Error Analysis
+
+```
+Attempted write on: /home/user/project/output/report.txt
+```
+
+This tells you:
+- The test tried to **write** a file (not just read)
+- The path is **outside** all allowed directories
+- You need to either mock the write or use `tmp_path`
+
+## Common Remediation Strategies
+
+### 1. Use tmp_path Fixture
+
+The simplest fix for tests that need temporary files:
+
+```python
+@pytest.mark.small
+def test_save_report(tmp_path):
+    output_file = tmp_path / "report.txt"
+    save_report(output_file)
+    assert output_file.exists()
+```
+
+### 2. Use io.StringIO or io.BytesIO
+
+For tests that need file-like objects but not actual files:
+
+```python
+from io import StringIO
+
+@pytest.mark.small
+def test_csv_writer():
+    buffer = StringIO()
+    write_csv(buffer, data)
+    assert "header1,header2" in buffer.getvalue()
+```
+
+### 3. Mock File Operations
+
+Use pytest-mock to intercept file operations:
+
+```python
+@pytest.mark.small
+def test_config_loader(mocker):
+    mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data="key=value"))
+    config = load_config("/etc/myapp/config.ini")
+    assert config["key"] == "value"
+```
+
+### 4. Use pyfakefs
+
+For comprehensive filesystem mocking:
+
+```python
+@pytest.mark.small
+def test_with_fake_filesystem(fs):  # pyfakefs fixture
+    fs.create_file("/etc/myapp/config.ini", contents="key=value")
+    config = load_config("/etc/myapp/config.ini")
+    assert config["key"] == "value"
+```
+
+### 5. Embed Test Data
+
+For read-only test data, embed it in your test code:
+
+```python
+TEST_CONFIG = """
+[database]
+host = localhost
+port = 5432
+"""
+
+@pytest.mark.small
+def test_config_parser():
+    config = parse_config(StringIO(TEST_CONFIG))
+    assert config["database"]["host"] == "localhost"
+```
+
+### 6. Use importlib.resources
+
+For package data files:
+
+```python
+from importlib import resources
+
+@pytest.mark.small
+def test_load_schema():
+    schema_text = resources.read_text("mypackage.schemas", "user.json")
+    schema = json.loads(schema_text)
+    assert "properties" in schema
+```
+
+### 7. Change Test Size
+
+If the test legitimately requires filesystem access, change its category:
+
+```python
+@pytest.mark.medium  # Medium tests can access filesystem
+def test_large_file_processing():
+    with open("/data/large_dataset.csv") as f:
+        process_file(f)
+```
+
+## Best Practices
+
+### 1. Start with WARN Mode
+
+When first enabling filesystem isolation, use warn mode to identify all violations:
+
+```bash
+pytest --test-categories-enforcement=warn 2>&1 | grep "Filesystem access violation"
+```
+
+### 2. Fix Violations Systematically
+
+Address violations in order of test frequency:
+
+1. Fix small tests first (they run most often)
+2. Use tmp_path for tests that need real files
+3. Use mocking for tests that don't need real filesystem
+4. Change test size only when filesystem access is essential
+
+### 3. Use Dependency Injection
+
+Design code to accept file paths or file-like objects as parameters:
+
+```python
+# Production code
+def save_report(data: dict, output: Path | TextIO) -> None:
+    if isinstance(output, Path):
+        output.write_text(json.dumps(data))
+    else:
+        output.write(json.dumps(data))
+
+# Test code - small test with mock
+@pytest.mark.small
+def test_save_report_to_stream():
+    buffer = StringIO()
+    save_report({"key": "value"}, buffer)
+    assert '"key"' in buffer.getvalue()
+
+# Test code - medium test with real file
+@pytest.mark.medium
+def test_save_report_to_file(tmp_path):
+    output_file = tmp_path / "report.json"
+    save_report({"key": "value"}, output_file)
+    assert output_file.exists()
+```
+
+### 4. Consider Test Size Carefully
+
+If a test genuinely requires filesystem access, consider whether it belongs in a different size category:
+
+- **Small**: Pure functions, in-memory operations, mocked I/O
+- **Medium**: File operations with tmp_path, config file parsing
+- **Large**: Integration with real filesystem paths
+
+## Related Documentation
+
+- [Architecture Decision Record: Filesystem Isolation](../architecture/adr-002-filesystem-isolation.md)
+- [Troubleshooting Filesystem Violations](../troubleshooting/filesystem-violations.md)
+- [Filesystem Isolation Examples](../examples/filesystem-isolation.md)
+- [Configuration Reference](../configuration.md)

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -16,18 +16,21 @@ timing-enforcement
 distribution-validation
 reporting
 network-isolation
+filesystem-isolation
 ```
 
 ## Quick Reference
 
 ### Test Size Markers
 
-| Marker | Time Limit | Network | Use Case |
-|--------|------------|---------|----------|
-| `@pytest.mark.small` | 1 second | Blocked | Unit tests |
-| `@pytest.mark.medium` | 5 minutes | Allowed | Integration tests |
-| `@pytest.mark.large` | 15 minutes | Allowed | E2E tests |
-| `@pytest.mark.xlarge` | 15 minutes | Allowed | Extended tests |
+| Marker | Time Limit | Network | Filesystem | Use Case |
+|--------|------------|---------|------------|----------|
+| `@pytest.mark.small` | 1 second | Blocked | Blocked* | Unit tests |
+| `@pytest.mark.medium` | 5 minutes | Allowed | Allowed | Integration tests |
+| `@pytest.mark.large` | 15 minutes | Allowed | Allowed | E2E tests |
+| `@pytest.mark.xlarge` | 15 minutes | Allowed | Allowed | Extended tests |
+
+*Small tests can access `tmp_path`, system temp directories, and configured allowed paths.
 
 ### Base Test Classes
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the filesystem isolation feature, completing the documentation deliverables for Issue #94.

### Documentation Added

- **User Guide** (`docs/user-guide/filesystem-isolation.md`)
  - What filesystem isolation is and why it matters
  - How it works (patching strategy)
  - Default allowed paths (system temp, pytest fixtures)
  - How to enable/configure enforcement
  - Understanding error messages
  - Common remediation strategies

- **Troubleshooting Guide** (`docs/troubleshooting/filesystem-violations.md`)
  - Common violation scenarios with examples
  - How to identify filesystem access
  - Debugging access patterns
  - Migration guide for existing test suites

- **Examples** (`docs/examples/filesystem-isolation.md`)
  - Tests that violate isolation (before)
  - Fixed versions using tmp_path (after)
  - Fixed versions using mocks (after)
  - Using medium test size for legitimate access
  - Configuration examples for CI/CD

- **Configuration Reference Updates** (`docs/configuration.md`)
  - `test_categories_allowed_paths` ini option
  - `--test-categories-allowed-paths` CLI option
  - Configuration options reference table

- **CHANGELOG.md**
  - Added v0.5.0 section with filesystem isolation features

- **README.md**
  - Updated "Network Isolation" section to "Resource Isolation"
  - Added filesystem isolation information and documentation links

- **Index Files**
  - Updated user-guide, troubleshooting, and examples index files to include new pages
  - Updated quick reference table with filesystem column

### Related Issues

- Fixes #94
- Part of Epic #66 (Resource Isolation)
- Depends on: #91 (ADR-002), #92 (port interface), #93 (adapters), #95 (design), #96, #97 (implementation)

## Test Plan

- [ ] Verify all documentation pages render correctly in Sphinx/MkDocs
- [ ] Check all cross-references and links work
- [ ] Verify code examples are syntactically correct
- [ ] Review documentation against ADR-002 for consistency
- [ ] Ensure CHANGELOG follows Keep a Changelog format