### PR TITLE
feat: add configurable distribution targets

### DIFF
--- a/src/pytest_test_categories/distribution/__init__.py
+++ b/src/pytest_test_categories/distribution/__init__.py
@@ -2,4 +2,5 @@
 
 from __future__ import annotations
 
+from .config import *  # noqa: F403
 from .stats import *  # noqa: F403

--- a/src/pytest_test_categories/distribution/config.py
+++ b/src/pytest_test_categories/distribution/config.py
@@ -1,0 +1,142 @@
+"""Distribution configuration for configurable target percentages.
+
+This module provides the DistributionConfig model for configuring
+custom distribution targets and tolerances for test sizes.
+
+Example:
+    >>> from pytest_test_categories.distribution.config import DistributionConfig
+    >>> config = DistributionConfig(
+    ...     small_target=70.0,
+    ...     medium_target=20.0,
+    ...     large_target=10.0,
+    ... )
+    >>> config.get_small_range()
+    DistributionRange(target=70.0, tolerance=5.0)
+
+"""
+
+from __future__ import annotations
+
+from typing import (
+    Annotated,
+    Final,
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+)
+
+from pytest_test_categories.distribution.stats import DistributionRange
+
+__all__ = [
+    'DEFAULT_DISTRIBUTION_CONFIG',
+    'DistributionConfig',
+]
+
+ONE_HUNDRED_PERCENT: Final[float] = 100.0
+ROUNDING_TOLERANCE: Final[float] = 0.03
+
+
+class DistributionConfig(BaseModel):
+    """Configuration for distribution targets across all test sizes.
+
+    This model holds configurable distribution targets and tolerances for each
+    test size category. Users can override the defaults via pyproject.toml,
+    pytest.ini, or CLI options.
+
+    Default values match Google's Software Engineering at Google recommendations:
+    - Small: 80% target (+/-5% tolerance)
+    - Medium: 15% target (+/-5% tolerance)
+    - Large/XLarge: 5% target (+/-3% tolerance)
+
+    Example:
+        >>> config = DistributionConfig(small_target=70.0, medium_target=20.0, large_target=10.0)
+        >>> config.get_small_range()
+        DistributionRange(target=70.0, tolerance=5.0)
+
+    """
+
+    small_target: Annotated[
+        float,
+        Field(ge=0.0, le=ONE_HUNDRED_PERCENT, description='Target percentage for small tests'),
+    ] = 80.0
+
+    medium_target: Annotated[
+        float,
+        Field(ge=0.0, le=ONE_HUNDRED_PERCENT, description='Target percentage for medium tests'),
+    ] = 15.0
+
+    large_target: Annotated[
+        float,
+        Field(ge=0.0, le=ONE_HUNDRED_PERCENT, description='Target percentage for large/xlarge tests'),
+    ] = 5.0
+
+    small_tolerance: Annotated[
+        float,
+        Field(gt=0.0, le=20.0, description='Tolerance percentage for small tests'),
+    ] = 5.0
+
+    medium_tolerance: Annotated[
+        float,
+        Field(gt=0.0, le=20.0, description='Tolerance percentage for medium tests'),
+    ] = 5.0
+
+    large_tolerance: Annotated[
+        float,
+        Field(gt=0.0, le=20.0, description='Tolerance percentage for large/xlarge tests'),
+    ] = 3.0
+
+    model_config = ConfigDict(frozen=True)
+
+    @property
+    def targets_sum(self) -> float:
+        """Calculate the sum of all target percentages.
+
+        Returns:
+            The sum of small_target, medium_target, and large_target.
+
+        """
+        return self.small_target + self.medium_target + self.large_target
+
+    @property
+    def targets_sum_to_100(self) -> bool:
+        """Check if targets sum to 100% within rounding tolerance.
+
+        Returns:
+            True if targets sum to approximately 100%, False otherwise.
+
+        """
+        return abs(self.targets_sum - ONE_HUNDRED_PERCENT) <= ROUNDING_TOLERANCE
+
+    def get_small_range(self) -> DistributionRange:
+        """Get the DistributionRange for small tests.
+
+        Returns:
+            DistributionRange configured for small tests.
+
+        """
+        return DistributionRange(target=self.small_target, tolerance=self.small_tolerance)
+
+    def get_medium_range(self) -> DistributionRange:
+        """Get the DistributionRange for medium tests.
+
+        Returns:
+            DistributionRange configured for medium tests.
+
+        """
+        return DistributionRange(target=self.medium_target, tolerance=self.medium_tolerance)
+
+    def get_large_xlarge_range(self) -> DistributionRange:
+        """Get the DistributionRange for large/xlarge tests combined.
+
+        Returns:
+            DistributionRange configured for large/xlarge tests.
+
+        """
+        return DistributionRange(target=self.large_target, tolerance=self.large_tolerance)
+
+
+# Default configuration matching Google's test size recommendations
+DEFAULT_DISTRIBUTION_CONFIG = DistributionConfig()

--- a/src/pytest_test_categories/types.py
+++ b/src/pytest_test_categories/types.py
@@ -383,6 +383,9 @@ class PluginState(BaseModel):
 
     The time_limit_config holds the configured time limits for each test size,
     allowing customization via pyproject.toml, pytest.ini, or CLI options.
+
+    The distribution_config holds the configured distribution targets and tolerances,
+    allowing customization via pyproject.toml, pytest.ini, or CLI options.
     """
 
     model_config = {'arbitrary_types_allowed': True}
@@ -399,6 +402,8 @@ class PluginState(BaseModel):
     test_discovery_service: object | None = None
     # Time limit configuration for each test size (configurable)
     time_limit_config: object | None = None  # TimeLimitConfig, avoiding circular import
+    # Distribution configuration for targets and tolerances (configurable)
+    distribution_config: object | None = None  # DistributionConfig, avoiding circular import
 
     def __init__(self, **data: object) -> None:
         """Initialize PluginState with defaults for circular import fields."""
@@ -416,6 +421,10 @@ class PluginState(BaseModel):
             from pytest_test_categories.timing import DEFAULT_TIME_LIMIT_CONFIG  # noqa: PLC0415
 
             self.time_limit_config = DEFAULT_TIME_LIMIT_CONFIG
+        if self.distribution_config is None:
+            from pytest_test_categories.distribution.config import DEFAULT_DISTRIBUTION_CONFIG  # noqa: PLC0415
+
+            self.distribution_config = DEFAULT_DISTRIBUTION_CONFIG
 
 
 # Add proper type hints for TYPE_CHECKING

--- a/tests/test_distribution_config_module.py
+++ b/tests/test_distribution_config_module.py
@@ -1,0 +1,236 @@
+"""Unit tests for the DistributionConfig model.
+
+This module tests the configuration model for custom distribution targets per test size.
+Tests follow TDD - these tests are written first, then implementation follows.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.small
+class DescribeDistributionConfig:
+    """Test suite for DistributionConfig model."""
+
+    def it_creates_with_default_targets(self) -> None:
+        """Create config with default distribution targets matching Google's recommendations."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        config = DistributionConfig()
+
+        assert config.small_target == 80.0
+        assert config.medium_target == 15.0
+        assert config.large_target == 5.0
+        assert config.small_tolerance == 5.0
+        assert config.medium_tolerance == 5.0
+        assert config.large_tolerance == 3.0
+
+    def it_creates_with_custom_targets(self) -> None:
+        """Create config with custom distribution targets."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        config = DistributionConfig(
+            small_target=70.0,
+            medium_target=20.0,
+            large_target=10.0,
+        )
+
+        assert config.small_target == 70.0
+        assert config.medium_target == 20.0
+        assert config.large_target == 10.0
+
+    def it_creates_with_custom_tolerances(self) -> None:
+        """Create config with custom tolerances."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        config = DistributionConfig(
+            small_tolerance=8.0,
+            medium_tolerance=8.0,
+            large_tolerance=5.0,
+        )
+
+        assert config.small_tolerance == 8.0
+        assert config.medium_tolerance == 8.0
+        assert config.large_tolerance == 5.0
+
+    def it_rejects_negative_targets(self) -> None:
+        """Reject negative target values."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        with pytest.raises(ValueError, match='Input should be greater than or equal to 0'):
+            DistributionConfig(small_target=-1.0)
+
+    def it_rejects_targets_over_100(self) -> None:
+        """Reject target values over 100%."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        with pytest.raises(ValueError, match='Input should be less than or equal to 100'):
+            DistributionConfig(small_target=101.0)
+
+    def it_rejects_zero_tolerance(self) -> None:
+        """Reject zero tolerance values."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        with pytest.raises(ValueError, match='Input should be greater than 0'):
+            DistributionConfig(small_tolerance=0.0)
+
+    def it_rejects_tolerance_over_20(self) -> None:
+        """Reject tolerance values over 20%."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        with pytest.raises(ValueError, match='Input should be less than or equal to 20'):
+            DistributionConfig(small_tolerance=21.0)
+
+    def it_is_frozen_immutable(self) -> None:
+        """Configuration is immutable after creation."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        config = DistributionConfig()
+
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match='Instance is frozen'):
+            config.small_target = 90.0  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@pytest.mark.small
+class DescribeDistributionConfigValidation:
+    """Test suite for target sum validation in DistributionConfig."""
+
+    def it_warns_when_targets_do_not_sum_to_100(self) -> None:
+        """Emit warning when targets do not sum to 100%."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        # targets sum to 90%, should still work but be flagged
+        config = DistributionConfig(
+            small_target=70.0,
+            medium_target=15.0,
+            large_target=5.0,
+        )
+        # Config should still be created
+        assert config.small_target == 70.0
+        # The targets_sum property should reflect the actual sum
+        assert config.targets_sum == 90.0
+        assert not config.targets_sum_to_100
+
+    def it_recognizes_when_targets_sum_to_100(self) -> None:
+        """Recognize when targets properly sum to 100%."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        config = DistributionConfig(
+            small_target=70.0,
+            medium_target=20.0,
+            large_target=10.0,
+        )
+
+        assert config.targets_sum == 100.0
+        assert config.targets_sum_to_100
+
+    def it_allows_targets_within_rounding_tolerance(self) -> None:
+        """Allow targets that sum to 100% within rounding tolerance."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        # Due to floating point, these might not sum to exactly 100.0
+        config = DistributionConfig(
+            small_target=80.01,
+            medium_target=14.99,
+            large_target=5.0,
+        )
+
+        # Should still be considered valid within tolerance
+        assert config.targets_sum_to_100
+
+
+@pytest.mark.small
+class DescribeDistributionConfigRanges:
+    """Test suite for getting distribution ranges from config."""
+
+    def it_provides_small_range(self) -> None:
+        """Provide DistributionRange for small tests."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+        from pytest_test_categories.distribution.stats import DistributionRange
+
+        config = DistributionConfig()
+        small_range = config.get_small_range()
+
+        assert isinstance(small_range, DistributionRange)
+        assert small_range.target == 80.0
+        assert small_range.tolerance == 5.0
+        assert small_range.min_value == 75.0
+        assert small_range.max_value == 85.0
+
+    def it_provides_medium_range(self) -> None:
+        """Provide DistributionRange for medium tests."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+        from pytest_test_categories.distribution.stats import DistributionRange
+
+        config = DistributionConfig()
+        medium_range = config.get_medium_range()
+
+        assert isinstance(medium_range, DistributionRange)
+        assert medium_range.target == 15.0
+        assert medium_range.tolerance == 5.0
+        assert medium_range.min_value == 10.0
+        assert medium_range.max_value == 20.0
+
+    def it_provides_large_xlarge_range(self) -> None:
+        """Provide DistributionRange for large/xlarge tests combined."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+        from pytest_test_categories.distribution.stats import DistributionRange
+
+        config = DistributionConfig()
+        large_range = config.get_large_xlarge_range()
+
+        assert isinstance(large_range, DistributionRange)
+        assert large_range.target == 5.0
+        assert large_range.tolerance == 3.0
+        assert large_range.min_value == 2.0
+        assert large_range.max_value == 8.0
+
+    def it_provides_custom_ranges(self) -> None:
+        """Provide custom ranges based on config."""
+        from pytest_test_categories.distribution.config import DistributionConfig
+
+        config = DistributionConfig(
+            small_target=70.0,
+            small_tolerance=10.0,
+            medium_target=20.0,
+            medium_tolerance=8.0,
+            large_target=10.0,
+            large_tolerance=5.0,
+        )
+
+        small_range = config.get_small_range()
+        assert small_range.target == 70.0
+        assert small_range.tolerance == 10.0
+        assert small_range.min_value == 60.0
+        assert small_range.max_value == 80.0
+
+        medium_range = config.get_medium_range()
+        assert medium_range.target == 20.0
+        assert medium_range.tolerance == 8.0
+
+        large_range = config.get_large_xlarge_range()
+        assert large_range.target == 10.0
+        assert large_range.tolerance == 5.0
+
+
+@pytest.mark.small
+class DescribeDefaultDistributionConfig:
+    """Test suite for DEFAULT_DISTRIBUTION_CONFIG constant."""
+
+    def it_has_default_config_constant(self) -> None:
+        """Module has DEFAULT_DISTRIBUTION_CONFIG constant."""
+        from pytest_test_categories.distribution.config import (
+            DEFAULT_DISTRIBUTION_CONFIG,
+            DistributionConfig,
+        )
+
+        assert isinstance(DEFAULT_DISTRIBUTION_CONFIG, DistributionConfig)
+        assert DEFAULT_DISTRIBUTION_CONFIG.small_target == 80.0
+        assert DEFAULT_DISTRIBUTION_CONFIG.medium_target == 15.0
+        assert DEFAULT_DISTRIBUTION_CONFIG.large_target == 5.0
+        assert DEFAULT_DISTRIBUTION_CONFIG.small_tolerance == 5.0
+        assert DEFAULT_DISTRIBUTION_CONFIG.medium_tolerance == 5.0
+        assert DEFAULT_DISTRIBUTION_CONFIG.large_tolerance == 3.0

--- a/tests/test_distribution_target_options_module.py
+++ b/tests/test_distribution_target_options_module.py
@@ -1,0 +1,255 @@
+"""Unit tests for configurable distribution target options.
+
+This module tests the pytest options for configuring distribution targets via
+pyproject.toml, pytest.ini, and CLI arguments.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from pytest_test_categories.distribution.config import (
+    DEFAULT_DISTRIBUTION_CONFIG,
+    DistributionConfig,
+)
+
+
+@pytest.mark.small
+class DescribePytestAddoptionDistributionTargets:
+    """Test that pytest_addoption registers distribution target options."""
+
+    def it_registers_individual_target_ini_options(self) -> None:
+        """Test that pytest_addoption registers individual target ini options."""
+        from pytest_test_categories import pytest_addoption
+
+        parser = Mock()
+        group = Mock()
+        parser.getgroup.return_value = group
+
+        pytest_addoption(parser)
+
+        expected_ini_options = [
+            'test_categories_small_target',
+            'test_categories_medium_target',
+            'test_categories_large_target',
+            'test_categories_tolerance',
+        ]
+        registered_ini_names = [call[0][0] for call in parser.addini.call_args_list]
+        for option in expected_ini_options:
+            assert option in registered_ini_names, f'{option} not registered'
+
+    def it_registers_cli_target_options(self) -> None:
+        """Test that pytest_addoption registers CLI distribution target options."""
+        from pytest_test_categories import pytest_addoption
+
+        parser = Mock()
+        group = Mock()
+        parser.getgroup.return_value = group
+
+        pytest_addoption(parser)
+
+        expected_cli_options = [
+            '--test-categories-small-target',
+            '--test-categories-medium-target',
+            '--test-categories-large-target',
+            '--test-categories-tolerance',
+        ]
+        registered_cli_options = [call[0][0] for call in group.addoption.call_args_list]
+        for option in expected_cli_options:
+            assert option in registered_cli_options, f'{option} not registered'
+
+
+@pytest.mark.small
+class DescribeGetDistributionConfig:
+    """Test the _get_distribution_config helper function."""
+
+    def it_returns_default_when_no_config_provided(self) -> None:
+        """Return default config when no options are set."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+        config.getoption.return_value = None
+        config.getini.return_value = ''
+
+        result = _get_distribution_config(config)
+
+        assert result == DEFAULT_DISTRIBUTION_CONFIG
+
+    def it_uses_cli_small_target_when_provided(self) -> None:
+        """CLI small target overrides defaults."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+
+        def mock_getoption(name: str, default: object = None) -> object:  # noqa: ARG001
+            if name == '--test-categories-small-target':
+                return 70.0
+            return None
+
+        def mock_getini(name: str) -> str:  # noqa: ARG001
+            return ''
+
+        config.getoption.side_effect = mock_getoption
+        config.getini.side_effect = mock_getini
+
+        result = _get_distribution_config(config)
+
+        assert result.small_target == 70.0
+        assert result.medium_target == 15.0  # default
+
+    def it_uses_cli_medium_target_when_provided(self) -> None:
+        """CLI medium target overrides defaults."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+
+        def mock_getoption(name: str, default: object = None) -> object:  # noqa: ARG001
+            if name == '--test-categories-medium-target':
+                return 20.0
+            return None
+
+        config.getoption.side_effect = mock_getoption
+        config.getini.return_value = ''
+
+        result = _get_distribution_config(config)
+
+        assert result.medium_target == 20.0
+
+    def it_uses_cli_large_target_when_provided(self) -> None:
+        """CLI large target overrides defaults."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+
+        def mock_getoption(name: str, default: object = None) -> object:  # noqa: ARG001
+            if name == '--test-categories-large-target':
+                return 10.0
+            return None
+
+        config.getoption.side_effect = mock_getoption
+        config.getini.return_value = ''
+
+        result = _get_distribution_config(config)
+
+        assert result.large_target == 10.0
+
+    def it_uses_cli_tolerance_for_all_sizes(self) -> None:
+        """CLI tolerance applies to all size categories."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+
+        def mock_getoption(name: str, default: object = None) -> object:  # noqa: ARG001
+            if name == '--test-categories-tolerance':
+                return 8.0
+            return None
+
+        config.getoption.side_effect = mock_getoption
+        config.getini.return_value = ''
+
+        result = _get_distribution_config(config)
+
+        assert result.small_tolerance == 8.0
+        assert result.medium_tolerance == 8.0
+        assert result.large_tolerance == 8.0
+
+    def it_uses_ini_target_when_cli_not_provided(self) -> None:
+        """Ini value used when CLI option not provided."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+        config.getoption.return_value = None
+
+        def mock_getini(name: str) -> str:
+            if name == 'test_categories_small_target':
+                return '70.0'
+            return ''
+
+        config.getini.side_effect = mock_getini
+
+        result = _get_distribution_config(config)
+
+        assert result.small_target == 70.0
+
+    def it_prefers_cli_over_ini_options(self) -> None:
+        """CLI takes precedence over ini options."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+
+        def mock_getoption(name: str, default: object = None) -> object:  # noqa: ARG001
+            if name == '--test-categories-small-target':
+                return 60.0
+            return None
+
+        def mock_getini(name: str) -> str:
+            if name == 'test_categories_small_target':
+                return '70.0'  # Should be ignored
+            return ''
+
+        config.getoption.side_effect = mock_getoption
+        config.getini.side_effect = mock_getini
+
+        result = _get_distribution_config(config)
+
+        assert result.small_target == 60.0
+
+    def it_combines_multiple_custom_targets(self) -> None:
+        """Combine multiple custom targets from different sources."""
+        from pytest_test_categories.plugin import _get_distribution_config
+
+        config = Mock()
+
+        def mock_getoption(name: str, default: object = None) -> object:  # noqa: ARG001
+            if name == '--test-categories-small-target':
+                return 70.0
+            if name == '--test-categories-tolerance':
+                return 8.0
+            return None
+
+        def mock_getini(name: str) -> str:
+            if name == 'test_categories_medium_target':
+                return '20.0'
+            if name == 'test_categories_large_target':
+                return '10.0'
+            return ''
+
+        config.getoption.side_effect = mock_getoption
+        config.getini.side_effect = mock_getini
+
+        result = _get_distribution_config(config)
+
+        assert result.small_target == 70.0
+        assert result.medium_target == 20.0
+        assert result.large_target == 10.0
+        assert result.small_tolerance == 8.0
+        assert result.medium_tolerance == 8.0
+        assert result.large_tolerance == 8.0
+
+
+@pytest.mark.small
+class DescribeDistributionConfigInPluginState:
+    """Test that distribution config is stored in PluginState."""
+
+    def it_stores_distribution_config_in_plugin_state(self) -> None:
+        """Plugin state includes distribution_config field."""
+        from pytest_test_categories.types import PluginState
+
+        state = PluginState()
+
+        assert hasattr(state, 'distribution_config')
+        assert state.distribution_config == DEFAULT_DISTRIBUTION_CONFIG
+
+    def it_allows_custom_distribution_config(self) -> None:
+        """Plugin state can be initialized with custom distribution config."""
+        from pytest_test_categories.types import PluginState
+
+        custom_config = DistributionConfig(small_target=70.0, medium_target=20.0, large_target=10.0)
+        state = PluginState(distribution_config=custom_config)
+
+        assert state.distribution_config == custom_config
+        config = state.distribution_config
+        assert isinstance(config, DistributionConfig)
+        assert config.small_target == 70.0


### PR DESCRIPTION
## Summary

Add CLI and INI options to configure test distribution targets and tolerances:
- `--test-categories-small-target` (default: 80%)
- `--test-categories-medium-target` (default: 15%)
- `--test-categories-large-target` (default: 5%)
- `--test-categories-tolerance` (default: 5%)

INI equivalents: `test_categories_small_target`, `test_categories_medium_target`, `test_categories_large_target`, `test_categories_tolerance`

## Changes

**New Files:**
- `src/pytest_test_categories/distribution/config.py` - DistributionConfig Pydantic model

**Modified Files:**
- `plugin.py` - Added 4 CLI options, 4 INI options
- `types.py` - Added `distribution_config` field to PluginState
- `distribution/stats.py` - Updated `validate_distribution()` to accept custom config
- `services/distribution_validation.py` - Uses configured targets in error messages

**Features:**
- `targets_sum_to_100` property for validation
- Tolerance must be 0-20%
- CLI overrides INI options
- Distribution validation uses configured values
- Error messages show configured targets

## Test Plan

- [x] 36 new tests for configuration
- [x] All 1196 tests pass
- [x] 98% overall coverage
- [x] Pre-commit hooks pass

Fixes #158