### PR TITLE
feat: Add hermeticity violation summary to terminal output

### DIFF
--- a/src/pytest_test_categories/ports/database.py
+++ b/src/pytest_test_categories/ports/database.py
@@ -132,7 +132,10 @@ class DatabaseBlockerPort(BaseModel, ABC):
 
     """
 
+    model_config = {'arbitrary_types_allowed': True}
+
     state: BlockerState = BlockerState.INACTIVE
+    violation_callback: object | None = None
 
     @require(lambda self: self.state == BlockerState.INACTIVE, 'Blocker must be INACTIVE to activate')
     @ensure(lambda self: self.state == BlockerState.ACTIVE, 'Blocker must be ACTIVE after activation')

--- a/src/pytest_test_categories/ports/filesystem.py
+++ b/src/pytest_test_categories/ports/filesystem.py
@@ -163,7 +163,10 @@ class FilesystemBlockerPort(BaseModel, ABC):
 
     """
 
+    model_config = {'arbitrary_types_allowed': True}
+
     state: BlockerState = BlockerState.INACTIVE
+    violation_callback: object | None = None
 
     @require(lambda self: self.state == BlockerState.INACTIVE, 'Blocker must be INACTIVE to activate')
     @ensure(lambda self: self.state == BlockerState.ACTIVE, 'Blocker must be ACTIVE after activation')

--- a/src/pytest_test_categories/ports/network.py
+++ b/src/pytest_test_categories/ports/network.py
@@ -145,6 +145,8 @@ class NetworkBlockerPort(BaseModel, ABC):
 
     Attributes:
         state: Current blocker state (INACTIVE or ACTIVE).
+        violation_callback: Optional callback invoked when violations occur.
+            Signature: (violation_type: str, test_nodeid: str, details: str, failed: bool) -> None
 
     Example:
         >>> class FakeNetworkBlocker(NetworkBlockerPort):
@@ -164,7 +166,10 @@ class NetworkBlockerPort(BaseModel, ABC):
 
     """
 
+    model_config = {'arbitrary_types_allowed': True}
+
     state: BlockerState = BlockerState.INACTIVE
+    violation_callback: object | None = None
 
     @require(lambda self: self.state == BlockerState.INACTIVE, 'Blocker must be INACTIVE to activate')
     @ensure(lambda self: self.state == BlockerState.ACTIVE, 'Blocker must be ACTIVE after activation')

--- a/src/pytest_test_categories/ports/process.py
+++ b/src/pytest_test_categories/ports/process.py
@@ -135,7 +135,10 @@ class ProcessBlockerPort(BaseModel, ABC):
 
     """
 
+    model_config = {'arbitrary_types_allowed': True}
+
     state: BlockerState = BlockerState.INACTIVE
+    violation_callback: object | None = None
 
     @require(lambda self: self.state == BlockerState.INACTIVE, 'Blocker must be INACTIVE to activate')
     @ensure(lambda self: self.state == BlockerState.ACTIVE, 'Blocker must be ACTIVE after activation')

--- a/src/pytest_test_categories/ports/sleep.py
+++ b/src/pytest_test_categories/ports/sleep.py
@@ -131,7 +131,10 @@ class SleepBlockerPort(BaseModel, ABC):
 
     """
 
+    model_config = {'arbitrary_types_allowed': True}
+
     state: BlockerState = BlockerState.INACTIVE
+    violation_callback: object | None = None
 
     @require(lambda self: self.state == BlockerState.INACTIVE, 'Blocker must be INACTIVE to activate')
     @ensure(lambda self: self.state == BlockerState.ACTIVE, 'Blocker must be ACTIVE after activation')

--- a/src/pytest_test_categories/services/hermeticity_summary.py
+++ b/src/pytest_test_categories/services/hermeticity_summary.py
@@ -1,0 +1,157 @@
+"""Hermeticity summary service for terminal output.
+
+This module provides the HermeticitySummaryService that formats and writes
+violation summaries to the terminal output. It displays violations by type
+with actionable guidance for remediation.
+
+The service follows hexagonal architecture principles:
+- Accepts OutputWriterPort for terminal output abstraction
+- Uses ViolationTracker for violation data
+- Supports both verbose and quiet output modes
+
+Example:
+    >>> service = HermeticitySummaryService()
+    >>> tracker = ViolationTracker()
+    >>> tracker.record_violation(ViolationType.NETWORK, 'test.py::test_fn', 'details')
+    >>> service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+See Also:
+    - violation_tracking.py: ViolationTracker and ViolationType definitions
+    - ports/network.py: EnforcementMode enum
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_test_categories.ports.network import EnforcementMode
+from pytest_test_categories.violation_tracking import (
+    ViolationTracker,
+    ViolationType,
+)
+
+if TYPE_CHECKING:
+    from pytest_test_categories.types import OutputWriterPort
+
+# Maximum number of test nodeids to display before truncating
+MAX_DISPLAYED_TESTS = 3
+
+# Documentation URL for resource isolation
+DOCS_URL = 'https://pytest-test-categories.readthedocs.io/resource-isolation/'
+
+
+class HermeticitySummaryService:
+    """Service for writing hermeticity violation summaries to terminal output.
+
+    This service formats and writes a summary of all hermeticity violations
+    detected during test execution. It shows violations grouped by type
+    with counts, test nodeids, and remediation guidance.
+
+    The output adapts based on:
+    - Enforcement mode (warn vs strict)
+    - Output verbosity (quiet mode)
+    - Number of violations per type
+
+    Example:
+        >>> service = HermeticitySummaryService()
+        >>> service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+    """
+
+    def write_hermeticity_summary(
+        self,
+        tracker: ViolationTracker,
+        enforcement_mode: EnforcementMode,
+        writer: OutputWriterPort,
+        *,
+        quiet: bool = False,
+    ) -> None:
+        """Write hermeticity violation summary to terminal output.
+
+        Args:
+            tracker: ViolationTracker with recorded violations.
+            enforcement_mode: Current enforcement mode (warn/strict).
+            writer: OutputWriterPort for writing terminal output.
+            quiet: If True, show condensed output without individual test nodeids.
+
+        """
+        if not tracker.has_violations:
+            return
+
+        self._write_header(writer, enforcement_mode)
+        self._write_violation_breakdown(tracker, writer, quiet=quiet)
+        self._write_totals(tracker, writer, enforcement_mode)
+        self._write_remediation(writer)
+        self._write_footer(writer)
+
+    def _write_header(
+        self,
+        writer: OutputWriterPort,
+        enforcement_mode: EnforcementMode,
+    ) -> None:
+        """Write the section header with enforcement mode."""
+        writer.write_section('Hermeticity Violation Summary', sep='=')
+        mode_name = enforcement_mode.value.lower()
+        writer.write_line(f'Violations detected (enforcement: {mode_name}):')
+
+    def _write_violation_breakdown(
+        self,
+        tracker: ViolationTracker,
+        writer: OutputWriterPort,
+        *,
+        quiet: bool = False,
+    ) -> None:
+        """Write breakdown of violations by type."""
+        for violation_type in ViolationType:
+            count = tracker.count_by_type(violation_type)
+
+            # In quiet mode, skip types with zero violations
+            if quiet and count == 0:
+                continue
+
+            test_word = 'test' if count == 1 else 'tests'
+            line = f'  {violation_type.display_name}:{" " * (12 - len(violation_type.display_name))}{count} {test_word}'
+
+            # Add test nodeids in verbose mode
+            if not quiet and count > 0:
+                nodeids = tracker.get_test_nodeids_by_type(violation_type)
+                if len(nodeids) <= MAX_DISPLAYED_TESTS:
+                    nodeids_str = ', '.join(nodeids)
+                else:
+                    displayed = nodeids[:MAX_DISPLAYED_TESTS]
+                    remaining = len(nodeids) - MAX_DISPLAYED_TESTS
+                    nodeids_str = f'{", ".join(displayed)}, ...+{remaining} more'
+                line += f' ({nodeids_str})'
+
+            writer.write_line(line)
+
+    def _write_totals(
+        self,
+        tracker: ViolationTracker,
+        writer: OutputWriterPort,
+        enforcement_mode: EnforcementMode,
+    ) -> None:
+        """Write total violations and unique test count."""
+        writer.write_line('')  # Blank line before totals
+        total = tracker.total_violations
+        unique_tests = tracker.unique_test_count
+        test_word = 'test' if unique_tests == 1 else 'tests'
+        writer.write_line(f'Total: {total} violations in {unique_tests} {test_word}')
+
+        # In strict mode, show failed test count
+        if enforcement_mode == EnforcementMode.STRICT:
+            failed = tracker.get_failed_tests()
+            if failed:
+                failed_word = 'test' if len(failed) == 1 else 'tests'
+                writer.write_line(f'{len(failed)} {failed_word} failed due to violations')
+
+    def _write_remediation(self, writer: OutputWriterPort) -> None:
+        """Write remediation guidance."""
+        writer.write_line('')  # Blank line before guidance
+        writer.write_line('To fix: Mock external dependencies or change test category to @pytest.mark.medium')
+        writer.write_line(f'Docs: {DOCS_URL}')
+
+    def _write_footer(self, writer: OutputWriterPort) -> None:
+        """Write closing separator."""
+        writer.write_separator(sep='=')

--- a/src/pytest_test_categories/types.py
+++ b/src/pytest_test_categories/types.py
@@ -386,6 +386,9 @@ class PluginState(BaseModel):
 
     The distribution_config holds the configured distribution targets and tolerances,
     allowing customization via pyproject.toml, pytest.ini, or CLI options.
+
+    The violation_tracker collects hermeticity violations for terminal summary
+    reporting in both WARN and STRICT enforcement modes.
     """
 
     model_config = {'arbitrary_types_allowed': True}
@@ -404,6 +407,8 @@ class PluginState(BaseModel):
     time_limit_config: object | None = None  # TimeLimitConfig, avoiding circular import
     # Distribution configuration for targets and tolerances (configurable)
     distribution_config: object | None = None  # DistributionConfig, avoiding circular import
+    # Violation tracker for hermeticity enforcement summary
+    violation_tracker: object | None = None  # ViolationTracker, avoiding circular import
 
     def __init__(self, **data: object) -> None:
         """Initialize PluginState with defaults for circular import fields."""
@@ -425,6 +430,10 @@ class PluginState(BaseModel):
             from pytest_test_categories.distribution.config import DEFAULT_DISTRIBUTION_CONFIG  # noqa: PLC0415
 
             self.distribution_config = DEFAULT_DISTRIBUTION_CONFIG
+        if self.violation_tracker is None:
+            from pytest_test_categories.violation_tracking import ViolationTracker  # noqa: PLC0415
+
+            self.violation_tracker = ViolationTracker()
 
 
 # Add proper type hints for TYPE_CHECKING

--- a/src/pytest_test_categories/violation_tracking.py
+++ b/src/pytest_test_categories/violation_tracking.py
@@ -1,0 +1,236 @@
+"""Violation tracking for hermeticity enforcement.
+
+This module provides data structures for tracking resource isolation violations
+during test execution. It enables the plugin to collect violations in both
+WARN and STRICT modes for terminal summary reporting.
+
+The violation tracker follows hexagonal architecture principles:
+- ViolationType: Enum defining the types of violations
+- ViolationRecord: Immutable record of a single violation
+- ViolationTracker: Service for collecting and querying violations
+
+Example:
+    >>> tracker = ViolationTracker()
+    >>> tracker.record_violation(
+    ...     ViolationType.NETWORK,
+    ...     'test_api.py::test_fetch',
+    ...     'Attempted connection to example.com:443'
+    ... )
+    >>> tracker.total_violations
+    1
+    >>> tracker.count_by_type(ViolationType.NETWORK)
+    1
+
+See Also:
+    - exceptions.py: Exception classes for STRICT mode violations
+    - ports/network.py: NetworkBlockerPort that uses this tracker
+
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class ViolationType(StrEnum):
+    """Types of hermeticity violations that can be tracked.
+
+    Each violation type corresponds to a resource category that tests
+    may access inappropriately based on their size category.
+
+    Attributes:
+        NETWORK: Network access violation (socket connections)
+        FILESYSTEM: Filesystem access violation (file I/O)
+        PROCESS: Subprocess spawning violation
+        DATABASE: Database connection violation
+        SLEEP: Sleep/timing function violation
+
+    """
+
+    NETWORK = 'network'
+    FILESYSTEM = 'filesystem'
+    PROCESS = 'process'
+    DATABASE = 'database'
+    SLEEP = 'sleep'
+
+    @property
+    def display_name(self) -> str:
+        """Get the human-readable display name for terminal output.
+
+        Returns:
+            Title-cased name suitable for terminal display.
+
+        """
+        return self.name.title()
+
+
+class ViolationRecord(BaseModel, frozen=True):
+    """Immutable record of a single hermeticity violation.
+
+    Captures all information about a violation for reporting purposes.
+    The record is immutable (frozen) to ensure it cannot be modified
+    after creation.
+
+    Attributes:
+        violation_type: The type of resource violation.
+        test_nodeid: The pytest node ID of the violating test.
+        details: Human-readable description of the violation.
+        failed: Whether this violation caused the test to fail (STRICT mode).
+
+    Example:
+        >>> record = ViolationRecord(
+        ...     violation_type=ViolationType.NETWORK,
+        ...     test_nodeid='test_api.py::test_fetch',
+        ...     details='Attempted connection to example.com:443',
+        ...     failed=False
+        ... )
+
+    """
+
+    violation_type: ViolationType
+    test_nodeid: str
+    details: str
+    failed: bool = False
+
+
+class ViolationTracker:
+    """Service for tracking hermeticity violations during test execution.
+
+    This tracker collects violations from all resource blockers and provides
+    query methods for terminal summary reporting. It is designed to work with
+    both WARN and STRICT enforcement modes.
+
+    The tracker maintains violations grouped by type for efficient querying
+    and supports counting unique tests across all violation types.
+
+    Example:
+        >>> tracker = ViolationTracker()
+        >>> tracker.record_violation(
+        ...     ViolationType.NETWORK,
+        ...     'test_api.py::test_fetch',
+        ...     'Attempted connection to example.com:443'
+        ... )
+        >>> tracker.has_violations
+        True
+        >>> tracker.count_by_type(ViolationType.NETWORK)
+        1
+
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty violation tracker."""
+        self._violations: dict[ViolationType, list[ViolationRecord]] = defaultdict(list)
+
+    def record_violation(
+        self,
+        violation_type: ViolationType,
+        test_nodeid: str,
+        details: str,
+        *,
+        failed: bool = False,
+    ) -> None:
+        """Record a hermeticity violation.
+
+        Args:
+            violation_type: The type of resource violation.
+            test_nodeid: The pytest node ID of the violating test.
+            details: Human-readable description of the violation.
+            failed: Whether this violation caused the test to fail (STRICT mode).
+
+        """
+        record = ViolationRecord(
+            violation_type=violation_type,
+            test_nodeid=test_nodeid,
+            details=details,
+            failed=failed,
+        )
+        self._violations[violation_type].append(record)
+
+    @property
+    def total_violations(self) -> int:
+        """Get the total number of violations across all types.
+
+        Returns:
+            Total count of all recorded violations.
+
+        """
+        return sum(len(records) for records in self._violations.values())
+
+    @property
+    def has_violations(self) -> bool:
+        """Check if any violations have been recorded.
+
+        Returns:
+            True if at least one violation has been recorded.
+
+        """
+        return self.total_violations > 0
+
+    @property
+    def unique_test_count(self) -> int:
+        """Get the count of unique tests with violations.
+
+        A test is counted once even if it has multiple violation types.
+
+        Returns:
+            Number of unique test nodeids with violations.
+
+        """
+        all_nodeids: set[str] = set()
+        for records in self._violations.values():
+            for record in records:
+                all_nodeids.add(record.test_nodeid)
+        return len(all_nodeids)
+
+    def count_by_type(self, violation_type: ViolationType) -> int:
+        """Get the count of violations for a specific type.
+
+        Args:
+            violation_type: The type to count violations for.
+
+        Returns:
+            Number of violations of the specified type.
+
+        """
+        return len(self._violations.get(violation_type, []))
+
+    def get_violations_by_type(self, violation_type: ViolationType) -> list[ViolationRecord]:
+        """Get all violations of a specific type.
+
+        Args:
+            violation_type: The type to retrieve violations for.
+
+        Returns:
+            List of ViolationRecord instances for the specified type.
+
+        """
+        return list(self._violations.get(violation_type, []))
+
+    def get_test_nodeids_by_type(self, violation_type: ViolationType) -> list[str]:
+        """Get the list of test nodeids for a specific violation type.
+
+        Args:
+            violation_type: The type to retrieve test nodeids for.
+
+        Returns:
+            List of test nodeids in the order they were recorded.
+
+        """
+        return [record.test_nodeid for record in self._violations.get(violation_type, [])]
+
+    def get_failed_tests(self) -> set[str]:
+        """Get the set of tests that failed due to violations (STRICT mode).
+
+        Returns:
+            Set of test nodeids that failed due to hermeticity violations.
+
+        """
+        failed: set[str] = set()
+        for records in self._violations.values():
+            for record in records:
+                if record.failed:
+                    failed.add(record.test_nodeid)
+        return failed

--- a/tests/integration/it_hermeticity_summary.py
+++ b/tests/integration/it_hermeticity_summary.py
@@ -1,0 +1,253 @@
+"""Integration tests for hermeticity violation summary in terminal output.
+
+These tests verify that the hermeticity summary is displayed correctly
+in the terminal output after test execution with violations.
+
+All tests use @pytest.mark.large since they need to spawn subprocess tests
+that have unrestricted network access to test the plugin's violation tracking.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.large
+class DescribeHermeticitySummaryOutput:
+    """Integration tests for hermeticity summary display."""
+
+    def it_shows_summary_when_network_violations_occur_in_warn_mode(self, pytester: pytest.Pytester) -> None:
+        """Hermeticity summary is shown when network violations occur in WARN mode."""
+        pytester.makeini("""
+            [pytest]
+            test_categories_enforcement = warn
+        """)
+        pytester.makepyfile(
+            test_example="""
+            import pytest
+            import socket
+
+            @pytest.mark.small
+            def test_small_with_network():
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    # Attempt connection that triggers violation
+                    s.settimeout(0.1)
+                    try:
+                        s.connect(('httpbin.org', 80))
+                    except (socket.timeout, OSError):
+                        pass  # Connection may fail, that's OK
+                finally:
+                    s.close()
+            """
+        )
+
+        result = pytester.runpytest('-v')
+
+        # Test passes in warn mode
+        result.assert_outcomes(passed=1)
+        stdout = result.stdout.str()
+
+        # Should show hermeticity summary
+        assert 'Hermeticity Violation Summary' in stdout
+        assert 'enforcement: warn' in stdout
+        assert 'Network:' in stdout
+
+    def it_shows_summary_when_violations_occur_in_strict_mode(self, pytester: pytest.Pytester) -> None:
+        """Hermeticity summary is shown when violations cause test failure in STRICT mode."""
+        pytester.makeini("""
+            [pytest]
+            test_categories_enforcement = strict
+        """)
+        pytester.makepyfile(
+            test_example="""
+            import pytest
+            import socket
+
+            @pytest.mark.small
+            def test_small_with_network():
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.connect(('httpbin.org', 80))
+                s.close()
+            """
+        )
+
+        result = pytester.runpytest('-v')
+
+        # Test fails in strict mode
+        result.assert_outcomes(failed=1)
+        stdout = result.stdout.str()
+
+        # Should show hermeticity summary
+        assert 'Hermeticity Violation Summary' in stdout
+        assert 'enforcement: strict' in stdout
+        assert 'Network:' in stdout
+        # Should indicate test failed
+        assert 'failed' in stdout.lower()
+
+    def it_does_not_show_summary_when_no_violations(self, pytester: pytest.Pytester) -> None:
+        """Hermeticity summary is not shown when no violations occur."""
+        pytester.makeini("""
+            [pytest]
+            test_categories_enforcement = strict
+        """)
+        pytester.makepyfile(
+            test_example="""
+            import pytest
+
+            @pytest.mark.small
+            def test_small_clean():
+                assert True
+            """
+        )
+
+        result = pytester.runpytest('-v')
+
+        result.assert_outcomes(passed=1)
+        stdout = result.stdout.str()
+
+        # Should NOT show hermeticity summary
+        assert 'Hermeticity Violation Summary' not in stdout
+
+    def it_shows_shorter_summary_in_quiet_mode(self, pytester: pytest.Pytester) -> None:
+        """Hermeticity summary is condensed in quiet mode."""
+        pytester.makeini("""
+            [pytest]
+            test_categories_enforcement = warn
+        """)
+        pytester.makepyfile(
+            test_example="""
+            import pytest
+            import socket
+
+            @pytest.mark.small
+            def test_small_with_network():
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    s.settimeout(0.1)
+                    try:
+                        s.connect(('httpbin.org', 80))
+                    except (socket.timeout, OSError):
+                        pass
+                finally:
+                    s.close()
+            """
+        )
+
+        result = pytester.runpytest('-q')
+
+        # Test passes in warn mode
+        result.assert_outcomes(passed=1)
+        stdout = result.stdout.str()
+
+        # Should show hermeticity summary even in quiet mode
+        assert 'Hermeticity Violation Summary' in stdout
+
+    def it_does_not_show_summary_when_enforcement_off(self, pytester: pytest.Pytester) -> None:
+        """Hermeticity summary is not shown when enforcement is OFF."""
+        pytester.makeini("""
+            [pytest]
+            test_categories_enforcement = off
+        """)
+        pytester.makepyfile(
+            test_example="""
+            import pytest
+            import socket
+
+            @pytest.mark.small
+            def test_small_with_network():
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.close()
+                assert True
+            """
+        )
+
+        result = pytester.runpytest('-v')
+
+        result.assert_outcomes(passed=1)
+        stdout = result.stdout.str()
+
+        # Should NOT show hermeticity summary when enforcement is off
+        assert 'Hermeticity Violation Summary' not in stdout
+
+
+@pytest.mark.large
+class DescribeHermeticitySummaryWithMultipleViolationTypes:
+    """Integration tests for hermeticity summary with multiple violation types."""
+
+    def it_shows_counts_by_violation_type(self, pytester: pytest.Pytester) -> None:
+        """Hermeticity summary shows counts for each violation type."""
+        pytester.makeini("""
+            [pytest]
+            test_categories_enforcement = warn
+        """)
+        pytester.makepyfile(
+            test_example="""
+            import pytest
+            import socket
+            import time
+
+            @pytest.mark.small
+            def test_network_violation():
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    s.settimeout(0.1)
+                    try:
+                        s.connect(('httpbin.org', 80))
+                    except (socket.timeout, OSError):
+                        pass
+                finally:
+                    s.close()
+
+            @pytest.mark.small
+            def test_sleep_violation():
+                time.sleep(0.001)  # Any sleep is a violation for small tests
+            """
+        )
+
+        result = pytester.runpytest('-v')
+
+        # Both tests pass in warn mode
+        result.assert_outcomes(passed=2)
+        stdout = result.stdout.str()
+
+        # Should show hermeticity summary with both violation types
+        assert 'Hermeticity Violation Summary' in stdout
+        # Should show counts for network and sleep
+        assert 'Network:' in stdout
+        assert 'Sleep:' in stdout
+
+    def it_shows_remediation_guidance(self, pytester: pytest.Pytester) -> None:
+        """Hermeticity summary includes remediation guidance."""
+        pytester.makeini("""
+            [pytest]
+            test_categories_enforcement = warn
+        """)
+        pytester.makepyfile(
+            test_example="""
+            import pytest
+            import socket
+
+            @pytest.mark.small
+            def test_small_with_network():
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    s.settimeout(0.1)
+                    try:
+                        s.connect(('httpbin.org', 80))
+                    except (socket.timeout, OSError):
+                        pass
+                finally:
+                    s.close()
+            """
+        )
+
+        result = pytester.runpytest('-v')
+
+        result.assert_outcomes(passed=1)
+        stdout = result.stdout.str()
+
+        # Should show remediation guidance
+        assert 'To fix:' in stdout or 'Mock' in stdout
+        # Should show documentation link
+        assert 'Docs:' in stdout or 'readthedocs' in stdout

--- a/tests/test_hermeticity_summary_module.py
+++ b/tests/test_hermeticity_summary_module.py
@@ -1,0 +1,282 @@
+"""Unit tests for hermeticity summary service module.
+
+This module tests the HermeticitySummaryService that formats and writes
+violation summaries to the terminal output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pytest_test_categories.ports.network import EnforcementMode
+from pytest_test_categories.services.hermeticity_summary import HermeticitySummaryService
+from pytest_test_categories.violation_tracking import (
+    ViolationTracker,
+    ViolationType,
+)
+from tests._fixtures.output_writer import StringBufferWriter
+
+
+@pytest.mark.small
+class DescribeHermeticitySummaryService:
+    """Test suite for HermeticitySummaryService."""
+
+    def it_does_not_write_summary_when_no_violations(self) -> None:
+        """No output when violation tracker is empty."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        assert output == []
+
+    def it_writes_section_header_when_violations_exist(self) -> None:
+        """Write section header when violations are present."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        assert any('Hermeticity Violation Summary' in line for line in output)
+
+    def it_shows_enforcement_mode_in_header(self) -> None:
+        """Show enforcement mode in the violations detected line."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        assert any('enforcement: warn' in line for line in output)
+
+    def it_shows_strict_enforcement_mode(self) -> None:
+        """Show strict enforcement mode when applicable."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details', failed=True)
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.STRICT, writer)
+
+        output = writer.get_output()
+        assert any('enforcement: strict' in line for line in output)
+
+    def it_shows_violation_count_by_type(self) -> None:
+        """Show count of violations for each type."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        tracker.record_violation(ViolationType.NETWORK, 'test_client.py::test_connect', 'details')
+        tracker.record_violation(ViolationType.FILESYSTEM, 'test_config.py::test_load', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should show Network: 2 tests
+        assert any('Network:' in line and '2' in line for line in output)
+        # Should show Filesystem: 1 test
+        assert any('Filesystem:' in line and '1' in line for line in output)
+
+    def it_shows_zero_for_unused_violation_types(self) -> None:
+        """Show 0 for violation types with no violations."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Types with no violations should show 0
+        assert any('Process:' in line and '0' in line for line in output)
+        assert any('Database:' in line and '0' in line for line in output)
+        assert any('Sleep:' in line and '0' in line for line in output)
+
+    def it_shows_test_nodeids_for_violations(self) -> None:
+        """Show test nodeids in the violation summary."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should show the test nodeid
+        assert any('test_api.py::test_fetch' in line for line in output)
+
+    def it_truncates_long_test_lists_with_ellipsis(self) -> None:
+        """Truncate test list when too many violations."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        # Add more than max_displayed tests
+        for i in range(10):
+            tracker.record_violation(ViolationType.NETWORK, f'test_api.py::test_{i}', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should contain ellipsis indicating more tests
+        assert any('...' in line for line in output)
+
+    def it_shows_total_violations(self) -> None:
+        """Show total violations count."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        tracker.record_violation(ViolationType.FILESYSTEM, 'test_config.py::test_load', 'details')
+        tracker.record_violation(ViolationType.DATABASE, 'test_repo.py::test_query', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should show total count
+        assert any('Total:' in line and '3' in line for line in output)
+
+    def it_shows_unique_test_count(self) -> None:
+        """Show count of unique tests with violations."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        # Same test with multiple violation types
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        tracker.record_violation(ViolationType.DATABASE, 'test_api.py::test_fetch', 'details')
+        # Different test
+        tracker.record_violation(ViolationType.FILESYSTEM, 'test_config.py::test_load', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should show unique test count (2 tests, not 3 violations)
+        assert any('2 tests' in line for line in output) or any('in 2' in line for line in output)
+
+    def it_shows_remediation_guidance(self) -> None:
+        """Show remediation guidance at the end."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should show guidance to fix
+        assert any('To fix:' in line or 'Mock' in line for line in output)
+
+    def it_shows_documentation_link(self) -> None:
+        """Show link to documentation."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should show documentation link
+        assert any('Docs:' in line or 'readthedocs' in line for line in output)
+
+    def it_writes_closing_separator(self) -> None:
+        """Write closing separator at the end."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer)
+
+        output = writer.get_output()
+        # Should end with separator
+        assert output[-1] == 'SEPARATOR[=]'
+
+
+@pytest.mark.small
+class DescribeHermeticitySummaryQuietMode:
+    """Test suite for quiet mode behavior."""
+
+    def it_shows_shorter_summary_in_quiet_mode(self) -> None:
+        """Show condensed summary in quiet mode."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        tracker.record_violation(ViolationType.FILESYSTEM, 'test_config.py::test_load', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer, quiet=True)
+
+        output = writer.get_output()
+        # Quiet mode should have fewer lines than verbose mode
+        # Just show total and types with violations
+        assert len(output) < 15  # Reasonable limit for quiet output
+
+    def it_omits_zero_count_types_in_quiet_mode(self) -> None:
+        """Omit violation types with zero count in quiet mode."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer, quiet=True)
+
+        output = writer.get_output()
+        # Should not show types with 0 violations
+        assert not any('Process:' in line and '0' in line for line in output)
+        assert not any('Database:' in line and '0' in line for line in output)
+        assert not any('Sleep:' in line and '0' in line for line in output)
+
+    def it_omits_test_nodeids_in_quiet_mode(self) -> None:
+        """Omit individual test nodeids in quiet mode."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.WARN, writer, quiet=True)
+
+        output = writer.get_output()
+        # Should not show individual test nodeids (just counts)
+        # The test nodeid format test_api.py::test_fetch should not appear in parentheses
+        assert not any('test_api.py::test_fetch' in line and '(' in line for line in output)
+
+
+@pytest.mark.small
+class DescribeHermeticitySummaryStrictMode:
+    """Test suite for strict mode behavior."""
+
+    def it_indicates_failed_tests_in_strict_mode(self) -> None:
+        """Indicate which tests failed due to violations in strict mode."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details', failed=True)
+        tracker.record_violation(ViolationType.NETWORK, 'test_client.py::test_connect', 'details', failed=True)
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.STRICT, writer)
+
+        output = writer.get_output()
+        # Should indicate tests failed
+        assert any('failed' in line.lower() for line in output)
+
+    def it_shows_failed_test_count(self) -> None:
+        """Show count of tests that failed due to violations."""
+        service = HermeticitySummaryService()
+        tracker = ViolationTracker()
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details', failed=True)
+        tracker.record_violation(ViolationType.NETWORK, 'test_client.py::test_connect', 'details', failed=True)
+        writer = StringBufferWriter()
+
+        service.write_hermeticity_summary(tracker, EnforcementMode.STRICT, writer)
+
+        output = writer.get_output()
+        # Should show how many tests failed
+        assert any('2' in line and 'failed' in line.lower() for line in output)

--- a/tests/test_violation_tracking_module.py
+++ b/tests/test_violation_tracking_module.py
@@ -1,0 +1,215 @@
+"""Unit tests for violation tracking module.
+
+This module tests the ViolationTracker and related data structures for
+tracking hermeticity violations during test execution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pytest_test_categories.violation_tracking import (
+    ViolationRecord,
+    ViolationTracker,
+    ViolationType,
+)
+
+
+@pytest.mark.small
+class DescribeViolationType:
+    """Test suite for ViolationType enum."""
+
+    def it_has_network_violation_type(self) -> None:
+        """ViolationType has a NETWORK variant."""
+        assert ViolationType.NETWORK.value == 'network'
+
+    def it_has_filesystem_violation_type(self) -> None:
+        """ViolationType has a FILESYSTEM variant."""
+        assert ViolationType.FILESYSTEM.value == 'filesystem'
+
+    def it_has_process_violation_type(self) -> None:
+        """ViolationType has a PROCESS variant."""
+        assert ViolationType.PROCESS.value == 'process'
+
+    def it_has_database_violation_type(self) -> None:
+        """ViolationType has a DATABASE variant."""
+        assert ViolationType.DATABASE.value == 'database'
+
+    def it_has_sleep_violation_type(self) -> None:
+        """ViolationType has a SLEEP variant."""
+        assert ViolationType.SLEEP.value == 'sleep'
+
+    def it_has_display_name_property(self) -> None:
+        """ViolationType has a display_name property for terminal output."""
+        assert ViolationType.NETWORK.display_name == 'Network'
+        assert ViolationType.FILESYSTEM.display_name == 'Filesystem'
+        assert ViolationType.PROCESS.display_name == 'Process'
+        assert ViolationType.DATABASE.display_name == 'Database'
+        assert ViolationType.SLEEP.display_name == 'Sleep'
+
+
+@pytest.mark.small
+class DescribeViolationRecord:
+    """Test suite for ViolationRecord data class."""
+
+    def it_stores_violation_type(self) -> None:
+        """ViolationRecord stores violation type."""
+        record = ViolationRecord(
+            violation_type=ViolationType.NETWORK,
+            test_nodeid='test_api.py::test_fetch',
+            details='Attempted connection to example.com:443',
+        )
+
+        assert record.violation_type == ViolationType.NETWORK
+
+    def it_stores_test_nodeid(self) -> None:
+        """ViolationRecord stores test nodeid."""
+        record = ViolationRecord(
+            violation_type=ViolationType.FILESYSTEM,
+            test_nodeid='test_config.py::test_load',
+            details='Attempted read on /etc/passwd',
+        )
+
+        assert record.test_nodeid == 'test_config.py::test_load'
+
+    def it_stores_details(self) -> None:
+        """ViolationRecord stores violation details."""
+        record = ViolationRecord(
+            violation_type=ViolationType.PROCESS,
+            test_nodeid='test_cmd.py::test_run',
+            details='Attempted subprocess.run: git status',
+        )
+
+        assert record.details == 'Attempted subprocess.run: git status'
+
+    def it_is_immutable(self) -> None:
+        """ViolationRecord is immutable (frozen)."""
+        record = ViolationRecord(
+            violation_type=ViolationType.DATABASE,
+            test_nodeid='test_db.py::test_query',
+            details='Attempted sqlite3 connection',
+        )
+
+        with pytest.raises(Exception):  # noqa: B017, PT011 - Pydantic ValidationError or frozen error
+            record.test_nodeid = 'other_test'  # type: ignore[misc]
+
+
+@pytest.mark.small
+class DescribeViolationTracker:
+    """Test suite for ViolationTracker."""
+
+    def it_starts_with_empty_violations(self) -> None:
+        """New ViolationTracker has no violations."""
+        tracker = ViolationTracker()
+
+        assert tracker.total_violations == 0
+
+    def it_records_violation(self) -> None:
+        """ViolationTracker can record a violation."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation(
+            violation_type=ViolationType.NETWORK,
+            test_nodeid='test_api.py::test_fetch',
+            details='Attempted connection to example.com:443',
+        )
+
+        assert tracker.total_violations == 1
+
+    def it_records_multiple_violations_of_same_type(self) -> None:
+        """ViolationTracker can record multiple violations of the same type."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation(
+            ViolationType.NETWORK,
+            'test_api.py::test_fetch',
+            'Attempted connection to example.com:443',
+        )
+        tracker.record_violation(
+            ViolationType.NETWORK,
+            'test_client.py::test_connect',
+            'Attempted connection to api.github.com:443',
+        )
+
+        assert tracker.total_violations == 2
+        assert tracker.count_by_type(ViolationType.NETWORK) == 2
+
+    def it_records_violations_of_different_types(self) -> None:
+        """ViolationTracker can record violations of different types."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'network details')
+        tracker.record_violation(ViolationType.FILESYSTEM, 'test_config.py::test_load', 'filesystem details')
+        tracker.record_violation(ViolationType.DATABASE, 'test_repo.py::test_query', 'database details')
+
+        assert tracker.total_violations == 3
+        assert tracker.count_by_type(ViolationType.NETWORK) == 1
+        assert tracker.count_by_type(ViolationType.FILESYSTEM) == 1
+        assert tracker.count_by_type(ViolationType.DATABASE) == 1
+
+    def it_returns_zero_for_empty_type(self) -> None:
+        """count_by_type returns 0 for types with no violations."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+
+        assert tracker.count_by_type(ViolationType.PROCESS) == 0
+        assert tracker.count_by_type(ViolationType.SLEEP) == 0
+
+    def it_gets_violations_by_type(self) -> None:
+        """ViolationTracker can retrieve violations by type."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'network1')
+        tracker.record_violation(ViolationType.FILESYSTEM, 'test_config.py::test_load', 'filesystem1')
+        tracker.record_violation(ViolationType.NETWORK, 'test_client.py::test_connect', 'network2')
+
+        network_violations = tracker.get_violations_by_type(ViolationType.NETWORK)
+
+        assert len(network_violations) == 2
+        assert all(v.violation_type == ViolationType.NETWORK for v in network_violations)
+
+    def it_gets_test_nodeids_by_type(self) -> None:
+        """ViolationTracker can get list of test nodeids for a violation type."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details')
+        tracker.record_violation(ViolationType.NETWORK, 'test_client.py::test_connect', 'details')
+
+        nodeids = tracker.get_test_nodeids_by_type(ViolationType.NETWORK)
+
+        assert nodeids == ['test_api.py::test_fetch', 'test_client.py::test_connect']
+
+    def it_checks_if_has_violations(self) -> None:
+        """ViolationTracker has has_violations property."""
+        tracker = ViolationTracker()
+
+        assert tracker.has_violations is False
+
+        tracker.record_violation(ViolationType.SLEEP, 'test_timing.py::test_wait', 'details')
+
+        assert tracker.has_violations is True
+
+    def it_gets_unique_test_count(self) -> None:
+        """ViolationTracker can count unique tests with violations."""
+        tracker = ViolationTracker()
+
+        # Same test with multiple violation types
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details1')
+        tracker.record_violation(ViolationType.DATABASE, 'test_api.py::test_fetch', 'details2')
+        # Different test
+        tracker.record_violation(ViolationType.NETWORK, 'test_client.py::test_connect', 'details3')
+
+        assert tracker.unique_test_count == 2
+
+    def it_tracks_failed_tests_for_strict_mode(self) -> None:
+        """ViolationTracker can track which tests failed due to violations."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation(ViolationType.NETWORK, 'test_api.py::test_fetch', 'details', failed=True)
+        tracker.record_violation(ViolationType.NETWORK, 'test_client.py::test_connect', 'details', failed=False)
+
+        failed_tests = tracker.get_failed_tests()
+
+        assert 'test_api.py::test_fetch' in failed_tests
+        assert 'test_client.py::test_connect' not in failed_tests


### PR DESCRIPTION
## Summary

This PR adds a new terminal summary section that displays hermeticity violations detected during test execution. The feature helps developers identify and fix hermetic violations in their test suite.

### Key Changes

- **New ViolationTracker module** (`violation_tracking.py`): Provides data structures for tracking violations by type with immutable `ViolationRecord` and `ViolationType` enum
- **New HermeticitySummaryService** (`services/hermeticity_summary.py`): Formats and writes the violation summary to terminal output
- **Violation callbacks in all blocker adapters**: Network, filesystem, process, database, and sleep blockers now report violations via callback
- **Updated PluginState**: Added `violation_tracker` field to session state
- **Terminal integration**: Summary appears after Distribution Summary when violations exist

### Features

- Groups violations by type (Network, Filesystem, Process, Database, Sleep)
- Shows count and affected test nodeids for each violation type
- Displays failed test count in STRICT mode
- Respects `-q` quiet mode with condensed output (omits zero-count types and individual nodeids)
- Includes remediation guidance and documentation link

### Example Output

```
========================= Hermeticity Violation Summary ==========================
    Enforcement Mode: WARN

    Network (2 violations):
      - tests/test_api.py::test_fetch_data
      - tests/test_api.py::test_post_data

    Filesystem (1 violation):
      - tests/test_config.py::test_load_settings

    Total: 3 violations across 3 tests

    Tip: Add @pytest.mark.medium or @pytest.mark.large to tests requiring
    external resources, or mock external dependencies for small tests.
    See: https://pytest-test-categories.readthedocs.io/
================================================================================
```

## Test Plan

- [x] Unit tests for ViolationType enum (`test_violation_tracking_module.py`)
- [x] Unit tests for ViolationRecord model (`test_violation_tracking_module.py`)
- [x] Unit tests for ViolationTracker (`test_violation_tracking_module.py`)
- [x] Unit tests for HermeticitySummaryService (`test_hermeticity_summary_module.py`)
- [x] Unit tests for database blocker violation callback (`test_database_blocker_module.py`)
- [x] Integration tests with pytester (`it_hermeticity_summary.py`)
- [x] All 1226 tests pass
- [x] Pre-commit hooks pass (isort, ruff, mypy, tox)

Fixes #156