### PR TITLE
feat: track hermeticity violations in JSON reports

### DIFF
--- a/docs/user-guide/reporting.md
+++ b/docs/user-guide/reporting.md
@@ -151,6 +151,145 @@ Warnings: 1
 ===========================================================================
 ```
 
+### JSON Report
+
+```bash
+pytest --test-size-report=json
+```
+
+JSON output is printed to stdout. To save to a file:
+
+```bash
+pytest --test-size-report=json --test-size-report-file=report.json
+```
+
+Output:
+
+```json
+{
+  "version": "1.0.0",
+  "timestamp": "2024-01-15T10:30:45.123456Z",
+  "summary": {
+    "total_tests": 55,
+    "distribution": {
+      "small": {"count": 45, "percentage": 81.8},
+      "medium": {"count": 8, "percentage": 14.5},
+      "large": {"count": 2, "percentage": 3.6},
+      "xlarge": {"count": 0, "percentage": 0.0}
+    },
+    "violations": {
+      "timing": 0,
+      "hermeticity": {
+        "network": 0,
+        "filesystem": 0,
+        "process": 0,
+        "database": 0,
+        "sleep": 0,
+        "total": 0
+      }
+    }
+  },
+  "tests": [
+    {
+      "name": "test_validation.py::test_email_valid",
+      "size": "small",
+      "duration": 0.001,
+      "status": "passed",
+      "violations": []
+    },
+    {
+      "name": "test_network.py::test_with_network_call",
+      "size": "small",
+      "duration": 0.234,
+      "status": "passed",
+      "violations": ["hermeticity:network"]
+    }
+  ]
+}
+```
+
+#### JSON Schema
+
+The JSON report includes:
+
+- **version**: Schema version (currently "1.0.0")
+- **timestamp**: ISO 8601 formatted UTC timestamp
+- **summary**: Aggregate statistics
+  - **total_tests**: Total number of tests
+  - **distribution**: Count and percentage by test size
+  - **violations**: Violation counts
+    - **timing**: Number of tests exceeding time limits
+    - **hermeticity**: Counts by violation type (network, filesystem, process, database, sleep, and total)
+- **tests**: Array of test entries with name, size, duration, status, and violations
+
+#### Hermeticity Violations
+
+When running with `--test-categories-enforcement=warn`, the JSON report tracks hermeticity violations:
+
+| Violation Type | Format in JSON | Description |
+|---------------|----------------|-------------|
+| Network | `hermeticity:network` | Blocked network connections |
+| Filesystem | `hermeticity:filesystem` | Blocked filesystem access |
+| Process | `hermeticity:process` | Blocked subprocess spawning |
+| Database | `hermeticity:database` | Blocked database connections |
+| Sleep | `hermeticity:sleep` | Blocked sleep calls |
+
+Example with violations:
+
+```bash
+pytest --test-size-report=json --test-categories-enforcement=warn --test-size-report-file=report.json
+```
+
+```json
+{
+  "version": "1.0.0",
+  "timestamp": "2024-01-15T10:30:45.123456Z",
+  "summary": {
+    "total_tests": 3,
+    "distribution": {
+      "small": {"count": 3, "percentage": 100.0},
+      "medium": {"count": 0, "percentage": 0.0},
+      "large": {"count": 0, "percentage": 0.0},
+      "xlarge": {"count": 0, "percentage": 0.0}
+    },
+    "violations": {
+      "timing": 1,
+      "hermeticity": {
+        "network": 1,
+        "filesystem": 0,
+        "process": 0,
+        "database": 2,
+        "sleep": 0,
+        "total": 3
+      }
+    }
+  },
+  "tests": [
+    {
+      "name": "test_slow.py::test_takes_too_long",
+      "size": "small",
+      "duration": 2.34,
+      "status": "passed",
+      "violations": ["timing"]
+    },
+    {
+      "name": "test_api.py::test_external_call",
+      "size": "small",
+      "duration": 0.01,
+      "status": "passed",
+      "violations": ["hermeticity:network"]
+    },
+    {
+      "name": "test_db.py::test_multiple_db_calls",
+      "size": "small",
+      "duration": 0.05,
+      "status": "passed",
+      "violations": ["hermeticity:database", "hermeticity:database"]
+    }
+  ]
+}
+```
+
 ## Customizing Output
 
 ### Verbose Mode

--- a/src/pytest_test_categories/adapters/database.py
+++ b/src/pytest_test_categories/adapters/database.py
@@ -236,7 +236,7 @@ class DatabasePatchingBlocker(DatabaseBlockerPort):
 
             """
             if not blocker._do_check_connection_allowed('sqlite3', database):  # noqa: SLF001
-                blocker._do_on_violation('sqlite3', database, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation('sqlite3', database, blocker.current_test_nodeid)
 
             return original_connect(database, *args, **kwargs)
 
@@ -398,7 +398,7 @@ class DatabasePatchingBlocker(DatabaseBlockerPort):
             connection_string = str(args[0]) if args else str(kwargs)
 
             if not blocker._do_check_connection_allowed(library, connection_string):  # noqa: SLF001
-                blocker._do_on_violation(library, connection_string, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation(library, connection_string, blocker.current_test_nodeid)
 
             return original_connect(*args, **kwargs)
 
@@ -424,7 +424,7 @@ class DatabasePatchingBlocker(DatabaseBlockerPort):
                 connection_string = host or 'localhost'
 
                 if not blocker._do_check_connection_allowed('pymongo', connection_string):  # noqa: SLF001
-                    blocker._do_on_violation('pymongo', connection_string, blocker.current_test_nodeid)  # noqa: SLF001
+                    blocker.on_violation('pymongo', connection_string, blocker.current_test_nodeid)
 
                 super().__init__(host, *args, **kwargs)
 
@@ -452,7 +452,7 @@ class DatabasePatchingBlocker(DatabaseBlockerPort):
                 connection_string = f'{host}:{kwargs.get("port", 6379)}'
 
                 if not blocker._do_check_connection_allowed(library, connection_string):  # noqa: SLF001
-                    blocker._do_on_violation(library, connection_string, blocker.current_test_nodeid)  # noqa: SLF001
+                    blocker.on_violation(library, connection_string, blocker.current_test_nodeid)
 
                 super().__init__(host, *args, **kwargs)
 
@@ -477,7 +477,7 @@ class DatabasePatchingBlocker(DatabaseBlockerPort):
             connection_string = str(url)
 
             if not blocker._do_check_connection_allowed('sqlalchemy', connection_string):  # noqa: SLF001
-                blocker._do_on_violation('sqlalchemy', connection_string, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation('sqlalchemy', connection_string, blocker.current_test_nodeid)
 
             return original_create_engine(url, *args, **kwargs)
 

--- a/src/pytest_test_categories/adapters/filesystem.py
+++ b/src/pytest_test_categories/adapters/filesystem.py
@@ -443,7 +443,7 @@ class FilesystemPatchingBlocker(FilesystemBlockerPort):
         def patched_method(self_path: Path, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
             path = Path(self_path)
             if not blocker._do_check_access_allowed(path, operation):  # noqa: SLF001
-                blocker._do_on_violation(path, operation, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation(path, operation, blocker.current_test_nodeid)
             return original(self_path, *args, **kwargs)
 
         return patched_method
@@ -472,7 +472,7 @@ class FilesystemPatchingBlocker(FilesystemBlockerPort):
             path = Path(self_path)
             operation = blocker._determine_operation_from_mode(mode)  # noqa: SLF001
             if not blocker._do_check_access_allowed(path, operation):  # noqa: SLF001
-                blocker._do_on_violation(path, operation, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation(path, operation, blocker.current_test_nodeid)
             return original(self_path, mode, *args, **kwargs)
 
         return patched_open
@@ -497,7 +497,7 @@ class FilesystemPatchingBlocker(FilesystemBlockerPort):
         def patched_func(path: str | Path, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
             path_obj = Path(path) if isinstance(path, str) else path
             if not blocker._do_check_access_allowed(path_obj, operation):  # noqa: SLF001
-                blocker._do_on_violation(path_obj, operation, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation(path_obj, operation, blocker.current_test_nodeid)
             return original(path, *args, **kwargs)
 
         return patched_func
@@ -520,9 +520,7 @@ class FilesystemPatchingBlocker(FilesystemBlockerPort):
         def patched_rename(src: str | Path, dst: str | Path, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
             src_path = Path(src) if isinstance(src, str) else src
             if not blocker._do_check_access_allowed(src_path, FilesystemOperation.MODIFY):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    src_path, FilesystemOperation.MODIFY, blocker.current_test_nodeid
-                )
+                blocker.on_violation(src_path, FilesystemOperation.MODIFY, blocker.current_test_nodeid)
             return original(src, dst, *args, **kwargs)
 
         return patched_rename
@@ -545,9 +543,7 @@ class FilesystemPatchingBlocker(FilesystemBlockerPort):
         def patched_copy(src: str | Path, dst: str | Path, *args: Any, **kwargs: Any) -> str:  # noqa: ANN401
             src_path = Path(src) if isinstance(src, str) else src
             if not blocker._do_check_access_allowed(src_path, FilesystemOperation.READ):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    src_path, FilesystemOperation.READ, blocker.current_test_nodeid
-                )
+                blocker.on_violation(src_path, FilesystemOperation.READ, blocker.current_test_nodeid)
             return original(src, dst, *args, **kwargs)
 
         return patched_copy
@@ -570,9 +566,7 @@ class FilesystemPatchingBlocker(FilesystemBlockerPort):
         def patched_rmtree(path: str | Path, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
             path_obj = Path(path) if isinstance(path, str) else path
             if not blocker._do_check_access_allowed(path_obj, FilesystemOperation.DELETE):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    path_obj, FilesystemOperation.DELETE, blocker.current_test_nodeid
-                )
+                blocker.on_violation(path_obj, FilesystemOperation.DELETE, blocker.current_test_nodeid)
             return original(path, *args, **kwargs)
 
         return patched_rmtree
@@ -617,7 +611,7 @@ class FilesystemPatchingBlocker(FilesystemBlockerPort):
             operation = blocker._determine_operation_from_mode(mode)  # noqa: SLF001
 
             if not blocker._do_check_access_allowed(path, operation):  # noqa: SLF001
-                blocker._do_on_violation(path, operation, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation(path, operation, blocker.current_test_nodeid)
 
             return original_open(file, mode, *args, **kwargs)
 

--- a/src/pytest_test_categories/adapters/network.py
+++ b/src/pytest_test_categories/adapters/network.py
@@ -212,9 +212,7 @@ class SocketPatchingNetworkBlocker(NetworkBlockerPort):
 
                     # Check if connection is allowed (accessing parent via closure)
                     if not blocker._do_check_connection_allowed(host, port):  # noqa: SLF001
-                        blocker._do_on_violation(  # noqa: SLF001
-                            host, port, blocker.current_test_nodeid
-                        )
+                        blocker.on_violation(host, port, blocker.current_test_nodeid)
 
                 # If we get here, either:
                 # 1. Connection is allowed
@@ -242,9 +240,7 @@ class SocketPatchingNetworkBlocker(NetworkBlockerPort):
 
                     # Check if connection is allowed (accessing parent via closure)
                     if not blocker._do_check_connection_allowed(host, port):  # noqa: SLF001
-                        blocker._do_on_violation(  # noqa: SLF001
-                            host, port, blocker.current_test_nodeid
-                        )
+                        blocker.on_violation(host, port, blocker.current_test_nodeid)
 
                 # If we get here, proceed with the actual connection
                 return super().connect_ex(address)  # type: ignore[no-any-return]

--- a/src/pytest_test_categories/adapters/process.py
+++ b/src/pytest_test_categories/adapters/process.py
@@ -294,9 +294,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
                 command, cmd_args = blocker._extract_command_and_args(args)  # noqa: SLF001
 
                 if not blocker._do_check_spawn_allowed(command, cmd_args):  # noqa: SLF001
-                    blocker._do_on_violation(  # noqa: SLF001
-                        command, cmd_args, blocker.current_test_nodeid, 'subprocess.Popen'
-                    )
+                    blocker.on_violation(command, cmd_args, blocker.current_test_nodeid, 'subprocess.Popen')
 
                 super().__init__(args, *pargs, **kwargs)
 
@@ -321,9 +319,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
             command, cmd_args = blocker._extract_command_and_args(args)  # noqa: SLF001
 
             if not blocker._do_check_spawn_allowed(command, cmd_args):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    command, cmd_args, blocker.current_test_nodeid, 'subprocess.run'
-                )
+                blocker.on_violation(command, cmd_args, blocker.current_test_nodeid, 'subprocess.run')
 
             return original_run(args, *pargs, **kwargs)  # type: ignore[no-any-return]
 
@@ -348,9 +344,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
             command, cmd_args = blocker._extract_command_and_args(args)  # noqa: SLF001
 
             if not blocker._do_check_spawn_allowed(command, cmd_args):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    command, cmd_args, blocker.current_test_nodeid, 'subprocess.call'
-                )
+                blocker.on_violation(command, cmd_args, blocker.current_test_nodeid, 'subprocess.call')
 
             return original_call(args, *pargs, **kwargs)  # type: ignore[no-any-return]
 
@@ -375,9 +369,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
             command, cmd_args = blocker._extract_command_and_args(args)  # noqa: SLF001
 
             if not blocker._do_check_spawn_allowed(command, cmd_args):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    command, cmd_args, blocker.current_test_nodeid, 'subprocess.check_call'
-                )
+                blocker.on_violation(command, cmd_args, blocker.current_test_nodeid, 'subprocess.check_call')
 
             return original_check_call(args, *pargs, **kwargs)  # type: ignore[no-any-return]
 
@@ -402,9 +394,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
             command, cmd_args = blocker._extract_command_and_args(args)  # noqa: SLF001
 
             if not blocker._do_check_spawn_allowed(command, cmd_args):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    command, cmd_args, blocker.current_test_nodeid, 'subprocess.check_output'
-                )
+                blocker.on_violation(command, cmd_args, blocker.current_test_nodeid, 'subprocess.check_output')
 
             return original_check_output(args, *pargs, **kwargs)  # type: ignore[no-any-return]
 
@@ -423,9 +413,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
         def patched_os_system(command: str) -> int:
             """Check permissions then delegate to actual os.system."""
             if not blocker._do_check_spawn_allowed(command, ()):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    command, (), blocker.current_test_nodeid, 'os.system'
-                )
+                blocker.on_violation(command, (), blocker.current_test_nodeid, 'os.system')
 
             return original_os_system(command)  # type: ignore[no-any-return]
 
@@ -448,9 +436,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
         ) -> Any:  # noqa: ANN401
             """Check permissions then delegate to actual os.popen."""
             if not blocker._do_check_spawn_allowed(cmd, ()):  # noqa: SLF001
-                blocker._do_on_violation(  # noqa: SLF001
-                    cmd, (), blocker.current_test_nodeid, 'os.popen'
-                )
+                blocker.on_violation(cmd, (), blocker.current_test_nodeid, 'os.popen')
 
             return original_os_popen(cmd, *pargs, **kwargs)
 
@@ -475,9 +461,7 @@ class SubprocessPatchingBlocker(ProcessBlockerPort):
                 target_name = getattr(target, '__name__', str(target)) if target else 'Process'
 
                 if not blocker._do_check_spawn_allowed(target_name, ()):  # noqa: SLF001
-                    blocker._do_on_violation(  # noqa: SLF001
-                        target_name, (), blocker.current_test_nodeid, 'multiprocessing.Process'
-                    )
+                    blocker.on_violation(target_name, (), blocker.current_test_nodeid, 'multiprocessing.Process')
 
                 super().start()
 

--- a/src/pytest_test_categories/adapters/sleep.py
+++ b/src/pytest_test_categories/adapters/sleep.py
@@ -219,7 +219,7 @@ class SleepPatchingBlocker(SleepBlockerPort):
 
             """
             if not blocker._do_check_sleep_allowed('time.sleep', seconds):  # noqa: SLF001
-                blocker._do_on_violation('time.sleep', seconds, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation('time.sleep', seconds, blocker.current_test_nodeid)
 
             original_sleep(seconds)
 
@@ -247,7 +247,7 @@ class SleepPatchingBlocker(SleepBlockerPort):
 
             """
             if not blocker._do_check_sleep_allowed('asyncio.sleep', delay):  # noqa: SLF001
-                blocker._do_on_violation('asyncio.sleep', delay, blocker.current_test_nodeid)  # noqa: SLF001
+                blocker.on_violation('asyncio.sleep', delay, blocker.current_test_nodeid)
 
             await original_sleep(delay)
 

--- a/src/pytest_test_categories/plugin.py
+++ b/src/pytest_test_categories/plugin.py
@@ -890,7 +890,12 @@ def _get_network_blocker(config: pytest.Config) -> SocketPatchingNetworkBlocker:
     """
     blocker_attr = '_test_categories_network_blocker'
     if not hasattr(config, blocker_attr):
-        blocker = SocketPatchingNetworkBlocker()
+        config_adapter = PytestConfigAdapter(config)
+        session_state = config_adapter.get_plugin_state()
+        violation_tracker = session_state.violation_tracker
+        blocker = SocketPatchingNetworkBlocker(
+            violation_callback=violation_tracker.record_violation if violation_tracker else None,
+        )
         setattr(config, blocker_attr, blocker)
     return cast('SocketPatchingNetworkBlocker', getattr(config, blocker_attr))
 
@@ -910,7 +915,12 @@ def _get_filesystem_blocker(config: pytest.Config) -> FilesystemPatchingBlocker:
     """
     blocker_attr = '_test_categories_filesystem_blocker'
     if not hasattr(config, blocker_attr):
-        blocker = FilesystemPatchingBlocker()
+        config_adapter = PytestConfigAdapter(config)
+        session_state = config_adapter.get_plugin_state()
+        violation_tracker = session_state.violation_tracker
+        blocker = FilesystemPatchingBlocker(
+            violation_callback=violation_tracker.record_violation if violation_tracker else None,
+        )
         setattr(config, blocker_attr, blocker)
     return cast('FilesystemPatchingBlocker', getattr(config, blocker_attr))
 
@@ -956,7 +966,12 @@ def _get_process_blocker(config: pytest.Config) -> SubprocessPatchingBlocker:
     """
     blocker_attr = '_test_categories_process_blocker'
     if not hasattr(config, blocker_attr):
-        blocker = SubprocessPatchingBlocker()
+        config_adapter = PytestConfigAdapter(config)
+        session_state = config_adapter.get_plugin_state()
+        violation_tracker = session_state.violation_tracker
+        blocker = SubprocessPatchingBlocker(
+            violation_callback=violation_tracker.record_violation if violation_tracker else None,
+        )
         setattr(config, blocker_attr, blocker)
     return cast('SubprocessPatchingBlocker', getattr(config, blocker_attr))
 
@@ -989,7 +1004,12 @@ def _get_sleep_blocker(config: pytest.Config) -> SleepPatchingBlocker:
     """
     blocker_attr = '_test_categories_sleep_blocker'
     if not hasattr(config, blocker_attr):
-        blocker = SleepPatchingBlocker()
+        config_adapter = PytestConfigAdapter(config)
+        session_state = config_adapter.get_plugin_state()
+        violation_tracker = session_state.violation_tracker
+        blocker = SleepPatchingBlocker(
+            violation_callback=violation_tracker.record_violation if violation_tracker else None,
+        )
         setattr(config, blocker_attr, blocker)
     return cast('SleepPatchingBlocker', getattr(config, blocker_attr))
 
@@ -1022,7 +1042,12 @@ def _get_database_blocker(config: pytest.Config) -> DatabasePatchingBlocker:
     """
     blocker_attr = '_test_categories_database_blocker'
     if not hasattr(config, blocker_attr):
-        blocker = DatabasePatchingBlocker()
+        config_adapter = PytestConfigAdapter(config)
+        session_state = config_adapter.get_plugin_state()
+        violation_tracker = session_state.violation_tracker
+        blocker = DatabasePatchingBlocker(
+            violation_callback=violation_tracker.record_violation if violation_tracker else None,
+        )
         setattr(config, blocker_attr, blocker)
     return cast('DatabasePatchingBlocker', getattr(config, blocker_attr))
 
@@ -1166,10 +1191,14 @@ def _write_json_report(
         terminalreporter: The terminal reporter for output.
 
     """
+    session_state = config_adapter.get_plugin_state()
+    violation_tracker = session_state.violation_tracker
+
     json_report = JsonReport.from_test_size_report(
         test_report=test_report,
         distribution_stats=stats,
         version=PLUGIN_VERSION,
+        violation_tracker=violation_tracker,
     )
 
     json_output = json_report.model_dump_json(indent=2)

--- a/src/pytest_test_categories/types.py
+++ b/src/pytest_test_categories/types.py
@@ -15,6 +15,8 @@ from icontract import (
 )
 from pydantic import BaseModel
 
+from pytest_test_categories.violations import ViolationTracker
+
 
 # TimingViolationError is now defined in timing.py with enhanced error messages
 # This is a re-export for backward compatibility
@@ -404,6 +406,8 @@ class PluginState(BaseModel):
     time_limit_config: object | None = None  # TimeLimitConfig, avoiding circular import
     # Distribution configuration for targets and tolerances (configurable)
     distribution_config: object | None = None  # DistributionConfig, avoiding circular import
+    # Violation tracker for hermeticity violations (network, filesystem, etc.)
+    violation_tracker: ViolationTracker | None = None  # avoiding circular import at runtime
 
     def __init__(self, **data: object) -> None:
         """Initialize PluginState with defaults for circular import fields."""
@@ -425,6 +429,10 @@ class PluginState(BaseModel):
             from pytest_test_categories.distribution.config import DEFAULT_DISTRIBUTION_CONFIG  # noqa: PLC0415
 
             self.distribution_config = DEFAULT_DISTRIBUTION_CONFIG
+        if self.violation_tracker is None:
+            from pytest_test_categories.violations import ViolationTracker  # noqa: PLC0415
+
+            self.violation_tracker = ViolationTracker()
 
 
 # Add proper type hints for TYPE_CHECKING

--- a/src/pytest_test_categories/violations.py
+++ b/src/pytest_test_categories/violations.py
@@ -1,0 +1,146 @@
+"""Hermeticity violation tracking for JSON reports.
+
+This module provides models and tracking for hermeticity violations
+(network, filesystem, process, database, sleep) that occur during test
+execution. These violations are collected and included in JSON reports
+for CI/CD integration.
+
+Example usage:
+    tracker = ViolationTracker()
+    tracker.record_violation('test_foo', ViolationType.NETWORK)
+    summary = tracker.get_summary()
+    # summary.network == 1, summary.total == 1
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from enum import StrEnum
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+)
+
+
+class ViolationType(StrEnum):
+    """Types of hermeticity violations that can occur during test execution.
+
+    Each violation type corresponds to a resource that small tests are
+    not permitted to access according to Google's test size definitions.
+    """
+
+    NETWORK = 'network'
+    FILESYSTEM = 'filesystem'
+    PROCESS = 'process'
+    DATABASE = 'database'
+    SLEEP = 'sleep'
+
+
+class HermeticityViolations(BaseModel):
+    """Summary of hermeticity violations by type.
+
+    This is an immutable (frozen) model that holds the count of each
+    violation type and computes the total automatically.
+
+    Attributes:
+        network: Count of network access violations.
+        filesystem: Count of filesystem access violations.
+        process: Count of subprocess/process spawning violations.
+        database: Count of database connection violations.
+        sleep: Count of sleep call violations.
+        total: Computed total of all violation types.
+
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    network: int = Field(default=0, ge=0)
+    filesystem: int = Field(default=0, ge=0)
+    process: int = Field(default=0, ge=0)
+    database: int = Field(default=0, ge=0)
+    sleep: int = Field(default=0, ge=0)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def total(self) -> int:
+        """Calculate the total number of violations across all types."""
+        return self.network + self.filesystem + self.process + self.database + self.sleep
+
+
+class ViolationTracker:
+    """Tracks hermeticity violations during test execution.
+
+    This class collects violations as they occur during test runs and
+    provides methods to retrieve both aggregate summaries and per-test
+    violation details for inclusion in JSON reports.
+
+    The tracker is designed to be used as a singleton per test session,
+    stored in PluginState.
+
+    Example:
+        >>> tracker = ViolationTracker()
+        >>> tracker.record_violation('test_foo', ViolationType.NETWORK)
+        >>> tracker.record_violation('test_foo', ViolationType.DATABASE)
+        >>> tracker.get_summary().total
+        2
+        >>> tracker.get_test_violations('test_foo')
+        [<ViolationType.NETWORK: 'network'>, <ViolationType.DATABASE: 'database'>]
+
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty violation tracker."""
+        self._violations_by_test: dict[str, list[ViolationType]] = defaultdict(list)
+        self._counts: dict[ViolationType, int] = dict.fromkeys(ViolationType, 0)
+
+    def record_violation(self, test_nodeid: str, violation_type: ViolationType) -> None:
+        """Record a hermeticity violation for a test.
+
+        Args:
+            test_nodeid: The pytest node ID of the test that caused the violation.
+            violation_type: The type of violation that occurred.
+
+        """
+        self._violations_by_test[test_nodeid].append(violation_type)
+        self._counts[violation_type] += 1
+
+    def get_summary(self) -> HermeticityViolations:
+        """Get a summary of all violations by type.
+
+        Returns:
+            An immutable HermeticityViolations model with counts for each
+            violation type and a computed total.
+
+        """
+        return HermeticityViolations(
+            network=self._counts[ViolationType.NETWORK],
+            filesystem=self._counts[ViolationType.FILESYSTEM],
+            process=self._counts[ViolationType.PROCESS],
+            database=self._counts[ViolationType.DATABASE],
+            sleep=self._counts[ViolationType.SLEEP],
+        )
+
+    def get_test_violations(self, test_nodeid: str) -> list[ViolationType]:
+        """Get the list of violations for a specific test.
+
+        Args:
+            test_nodeid: The pytest node ID of the test.
+
+        Returns:
+            A list of ViolationType values for the test. Returns an empty
+            list if the test has no recorded violations.
+
+        """
+        return list(self._violations_by_test.get(test_nodeid, []))
+
+    def reset(self) -> None:
+        """Reset the tracker to its initial empty state.
+
+        This clears all recorded violations and resets counts to zero.
+
+        """
+        self._violations_by_test.clear()
+        self._counts = dict.fromkeys(ViolationType, 0)

--- a/tests/test_violation_tracker_module.py
+++ b/tests/test_violation_tracker_module.py
@@ -1,0 +1,201 @@
+"""Unit tests for ViolationTracker and hermeticity violation tracking.
+
+This module tests the violation tracking system that records hermeticity
+violations (network, filesystem, process, database, sleep) during test
+execution for inclusion in JSON reports.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pytest_test_categories.violations import (
+    HermeticityViolations,
+    ViolationTracker,
+    ViolationType,
+)
+
+
+@pytest.mark.small
+class DescribeViolationType:
+    """Test suite for ViolationType enum."""
+
+    def it_has_all_violation_types(self) -> None:
+        """Verify all expected violation types exist."""
+        assert ViolationType.NETWORK.value == 'network'
+        assert ViolationType.FILESYSTEM.value == 'filesystem'
+        assert ViolationType.PROCESS.value == 'process'
+        assert ViolationType.DATABASE.value == 'database'
+        assert ViolationType.SLEEP.value == 'sleep'
+
+
+@pytest.mark.small
+class DescribeHermeticityViolations:
+    """Test suite for HermeticityViolations model."""
+
+    def it_initializes_with_zero_counts(self) -> None:
+        """Initialize with all violation counts at zero."""
+        violations = HermeticityViolations()
+
+        assert violations.network == 0
+        assert violations.filesystem == 0
+        assert violations.process == 0
+        assert violations.database == 0
+        assert violations.sleep == 0
+
+    def it_calculates_total_correctly(self) -> None:
+        """Calculate total from all violation types."""
+        violations = HermeticityViolations(
+            network=3,
+            filesystem=2,
+            process=0,
+            database=1,
+            sleep=0,
+        )
+
+        assert violations.total == 6
+
+    def it_is_frozen(self) -> None:
+        """Verify the model is immutable."""
+        from pydantic import ValidationError
+
+        violations = HermeticityViolations()
+
+        with pytest.raises(ValidationError, match='frozen'):
+            violations.network = 5
+
+    def it_converts_to_dict(self) -> None:
+        """Convert to dictionary for JSON serialization."""
+        violations = HermeticityViolations(
+            network=3,
+            filesystem=2,
+            process=0,
+            database=1,
+            sleep=0,
+        )
+
+        result = violations.model_dump()
+
+        assert result == {
+            'network': 3,
+            'filesystem': 2,
+            'process': 0,
+            'database': 1,
+            'sleep': 0,
+            'total': 6,
+        }
+
+
+@pytest.mark.small
+class DescribeViolationTracker:
+    """Test suite for ViolationTracker."""
+
+    def it_initializes_empty(self) -> None:
+        """Initialize with no violations recorded."""
+        tracker = ViolationTracker()
+
+        assert tracker.get_summary().total == 0
+        assert tracker.get_test_violations('test_foo') == []
+
+    def it_records_network_violation(self) -> None:
+        """Record a network violation for a test."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_example::test_foo', ViolationType.NETWORK)
+
+        assert tracker.get_summary().network == 1
+        assert ViolationType.NETWORK in tracker.get_test_violations('test_example::test_foo')
+
+    def it_records_filesystem_violation(self) -> None:
+        """Record a filesystem violation for a test."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_example::test_bar', ViolationType.FILESYSTEM)
+
+        assert tracker.get_summary().filesystem == 1
+        assert ViolationType.FILESYSTEM in tracker.get_test_violations('test_example::test_bar')
+
+    def it_records_process_violation(self) -> None:
+        """Record a process violation for a test."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_example::test_baz', ViolationType.PROCESS)
+
+        assert tracker.get_summary().process == 1
+        assert ViolationType.PROCESS in tracker.get_test_violations('test_example::test_baz')
+
+    def it_records_database_violation(self) -> None:
+        """Record a database violation for a test."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_example::test_db', ViolationType.DATABASE)
+
+        assert tracker.get_summary().database == 1
+        assert ViolationType.DATABASE in tracker.get_test_violations('test_example::test_db')
+
+    def it_records_sleep_violation(self) -> None:
+        """Record a sleep violation for a test."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_example::test_sleep', ViolationType.SLEEP)
+
+        assert tracker.get_summary().sleep == 1
+        assert ViolationType.SLEEP in tracker.get_test_violations('test_example::test_sleep')
+
+    def it_records_multiple_violations_for_same_test(self) -> None:
+        """Record multiple violations for the same test."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_foo', ViolationType.NETWORK)
+        tracker.record_violation('test_foo', ViolationType.FILESYSTEM)
+        tracker.record_violation('test_foo', ViolationType.DATABASE)
+
+        violations = tracker.get_test_violations('test_foo')
+        assert len(violations) == 3
+        assert ViolationType.NETWORK in violations
+        assert ViolationType.FILESYSTEM in violations
+        assert ViolationType.DATABASE in violations
+
+    def it_records_violations_across_multiple_tests(self) -> None:
+        """Record violations across multiple tests."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_one', ViolationType.NETWORK)
+        tracker.record_violation('test_two', ViolationType.NETWORK)
+        tracker.record_violation('test_three', ViolationType.FILESYSTEM)
+
+        summary = tracker.get_summary()
+        assert summary.network == 2
+        assert summary.filesystem == 1
+        assert summary.total == 3
+
+    def it_returns_empty_list_for_unknown_test(self) -> None:
+        """Return empty list for test with no recorded violations."""
+        tracker = ViolationTracker()
+
+        violations = tracker.get_test_violations('unknown_test')
+
+        assert violations == []
+
+    def it_records_same_violation_type_multiple_times(self) -> None:
+        """Record the same violation type multiple times for a test."""
+        tracker = ViolationTracker()
+
+        tracker.record_violation('test_foo', ViolationType.NETWORK)
+        tracker.record_violation('test_foo', ViolationType.NETWORK)
+
+        violations = tracker.get_test_violations('test_foo')
+        assert len(violations) == 2
+        assert tracker.get_summary().network == 2
+
+    def it_resets_to_initial_state(self) -> None:
+        """Reset tracker to initial empty state."""
+        tracker = ViolationTracker()
+        tracker.record_violation('test_foo', ViolationType.NETWORK)
+        tracker.record_violation('test_bar', ViolationType.DATABASE)
+
+        tracker.reset()
+
+        assert tracker.get_summary().total == 0
+        assert tracker.get_test_violations('test_foo') == []
+        assert tracker.get_test_violations('test_bar') == []


### PR DESCRIPTION
## Summary
Track actual hermeticity violations (network, filesystem, process, database, sleep) in JSON reports instead of the placeholder `hermeticity: 0`.

## Changes
- Added `ViolationType` enum for the 5 violation categories
- Added `HermeticityViolations` Pydantic model with counts by type and computed total
- Added `ViolationTracker` class to record violations per test during execution
- Updated `JsonReport` to include `hermeticity_violations` in the summary section
- Added per-test violation details to test entries in JSON report
- Wired violation callbacks to all 5 blocker adapters (network, filesystem, process, database, sleep)
- Updated JSON report documentation with new schema

## JSON Report Schema
```json
{
  "summary": {
    "violations": {
      "timing": 0,
      "hermeticity": {
        "network": 1,
        "filesystem": 0,
        "process": 0,
        "database": 2,
        "sleep": 0,
        "total": 3
      }
    }
  },
  "tests": [
    {
      "name": "test_api.py::test_external_call",
      "violations": ["hermeticity:network"]
    }
  ]
}
```

## Test plan
- [x] Unit tests for ViolationType, HermeticityViolations, ViolationTracker
- [x] Integration tests for JSON report output
- [x] Pre-commit hooks pass (isort, ruff, mypy, tox)
- [x] All existing tests pass

Fixes #155