### PR TITLE
feat: Wire violation tracker to JSON reports

### DIFF
--- a/src/pytest_test_categories/plugin.py
+++ b/src/pytest_test_categories/plugin.py
@@ -611,7 +611,7 @@ def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:
         test_report = cast('TestSizeReport', session_state.test_size_report)
         report_type = config_adapter.get_option('--test-size-report')
         if report_type == 'json':
-            _write_json_report(test_report, stats, config_adapter, terminalreporter)
+            _write_json_report(test_report, stats, config_adapter, terminalreporter, violation_tracker)
         elif report_type == 'detailed':
             test_report.write_detailed_report(terminalreporter)
         else:
@@ -1208,6 +1208,7 @@ def _write_json_report(
     stats: DistributionStatsType,
     config_adapter: PytestConfigAdapterType,
     terminalreporter: pytest.TerminalReporter,
+    violation_tracker: ViolationTracker | None = None,
 ) -> None:
     """Write JSON report to file or stdout.
 
@@ -1216,12 +1217,14 @@ def _write_json_report(
         stats: The distribution statistics.
         config_adapter: The config adapter for accessing options.
         terminalreporter: The terminal reporter for output.
+        violation_tracker: Optional violation tracker with hermeticity violations.
 
     """
     json_report = JsonReport.from_test_size_report(
         test_report=test_report,
         distribution_stats=stats,
         version=PLUGIN_VERSION,
+        violation_tracker=violation_tracker,
     )
 
     json_output = json_report.model_dump_json(indent=2)


### PR DESCRIPTION
## Summary

- Wire `ViolationTracker` to JSON report generation in `_write_json_report()` function
- Pass violation tracker from `pytest_terminal_summary()` to JSON report factory method
- Update `ViolationsSummary` model to use `HermeticityViolationsSummary` with per-type breakdown (network, filesystem, process, database, sleep) and computed total
- Add comprehensive tests for hermeticity violations in JSON report output

The JSON report now includes detailed hermeticity violation data:
- Summary-level violation counts by type (`summary.violations.hermeticity.network`, etc.)
- Computed `total` field for aggregate violation count
- Per-test violation entries with `hermeticity:type` format

Fixes #155

## Test plan

- [x] Run `uv run coverage run -m pytest tests/test_json_report_module.py -v` - all 30 tests pass
- [x] Run full test suite (excluding pre-existing benchmark errors) - all 1236 tests pass
- [x] Verify 100% coverage on `json_report.py`
- [x] Run `uv run ruff check --fix . && uv run ruff format .` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)