### PR TITLE
docs: add "architecture tool" thesis to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@
   <a href="#why-pytest-test-categories">Why?</a>
 </p>
 
+<p align="center">
+  <em>
+    <strong>This is an architecture tool disguised as a testing plugin.</strong><br>
+    When small tests are truly hermetic, code naturally evolves toward explicit boundaries<br>
+    and injectable dependencies. Strict enforcement isn't punitive—it's design feedback.
+  </em>
+</p>
+
 ---
 
 ## Quickstart


### PR DESCRIPTION
## Summary

Adds a prominent callout to the README positioning pytest-test-categories as an **architecture tool**, not just a testing plugin.

> **This is an architecture tool disguised as a testing plugin.**
> When small tests are truly hermetic, code naturally evolves toward explicit boundaries
> and injectable dependencies. Strict enforcement isn't punitive—it's design feedback.

## Why This Matters

- **Sets expectations immediately** for new users
- **Differentiates** from "yet another pytest marker plugin"
- **Connects to the broader thesis**: constraints drive design
- **Primes readers** before they hit the doctrine sections

This change was identified during external review as a high-priority documentation improvement that would significantly improve first-contact experience.

## Related

Part of documentation improvements identified in ChatGPT review feedback.

Fixes #201