### PR TITLE
feat: Add per-test performance baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Detects method marker conflicting with class marker
   - Warnings include guidance on resolving conflicts
   - Use `@pytest.mark.small(override=True)` to suppress warnings for intentional overrides
+- **Per-test performance baselines**: Define custom timeout limits stricter than category defaults using `@pytest.mark.small(timeout=0.1)`. When a test exceeds its custom baseline, a distinct `PerformanceBaselineViolationError` is raised showing both the baseline and category limits. JSON reports track baseline violations separately from timing violations. (#162)
 
 ## v1.1.0 (2025-12-04)
 

--- a/src/pytest_test_categories/errors.py
+++ b/src/pytest_test_categories/errors.py
@@ -144,6 +144,17 @@ TIMING_VIOLATION = ErrorCode(
     doc_url=f'{DOCS_BASE_URL}/errors/timing-limits.html',
 )
 
+PERFORMANCE_BASELINE_VIOLATION = ErrorCode(
+    code='TC008',
+    title='Performance Baseline Violation',
+    why_it_matters=(
+        'This test has a custom performance baseline stricter than its category limit. '
+        'Custom baselines are used for performance-critical tests that must complete faster '
+        'than the category default to catch performance regressions early.'
+    ),
+    doc_url=f'{DOCS_BASE_URL}/errors/performance-baselines.html',
+)
+
 # =============================================================================
 # Distribution Warnings (TC200-TC299)
 # =============================================================================
@@ -170,6 +181,7 @@ ERROR_CODES: dict[str, ErrorCode] = {
     'database_violation': DATABASE_VIOLATION,
     'sleep_violation': SLEEP_VIOLATION,
     'timing_violation': TIMING_VIOLATION,
+    'performance_baseline_violation': PERFORMANCE_BASELINE_VIOLATION,
     'distribution_warning': DISTRIBUTION_WARNING,
 }
 

--- a/src/pytest_test_categories/services/timing_validation.py
+++ b/src/pytest_test_categories/services/timing_validation.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pytest_test_categories import timing
+from pytest_test_categories.timing import validate_with_baseline
 from pytest_test_categories.types import (
     TestSize,
     TestTimer,
@@ -163,3 +164,43 @@ class TimingValidationService:
 
         """
         timers.pop(nodeid, None)
+
+    def validate_timing_with_baseline(
+        self,
+        test_size: TestSize,
+        duration: float,
+        baseline: float | None,
+        test_nodeid: str = '',
+    ) -> None:
+        """Validate test timing against a custom baseline or category limit.
+
+        When a custom baseline is provided, the test must complete within that
+        stricter limit. If the baseline is exceeded, a PerformanceBaselineViolationError
+        is raised. If no baseline is provided, falls back to standard category limit
+        validation.
+
+        This delegates to the timing module's validate_with_baseline() function
+        to check if the duration is within the baseline or category limit.
+
+        Args:
+            test_size: The size category of the test.
+            duration: The test duration in seconds.
+            baseline: Optional custom performance baseline in seconds.
+                If None, uses the category's default time limit.
+            test_nodeid: Optional pytest node ID for enhanced error messages.
+
+        Raises:
+            PerformanceBaselineViolationError: If duration exceeds the custom baseline.
+            TimingViolationError: If duration exceeds category limit (when no baseline).
+            ValueError: If baseline exceeds the category's time limit.
+
+        Example:
+            >>> service = TimingValidationService()
+            >>> service.validate_timing_with_baseline(TestSize.SMALL, 0.05, baseline=0.1)  # OK
+            >>> service.validate_timing_with_baseline(TestSize.SMALL, 0.15, baseline=0.1)
+            Traceback (most recent call last):
+                ...
+            PerformanceBaselineViolationError: ...
+
+        """
+        validate_with_baseline(test_size, duration, baseline, test_nodeid)

--- a/tests/test_performance_baseline_feature.py
+++ b/tests/test_performance_baseline_feature.py
@@ -1,0 +1,193 @@
+"""Integration tests for performance baseline feature.
+
+These tests use pytester to test the plugin's handling of custom timeout
+parameters in markers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def baseline_test_file(pytester: pytest.Pytester, request: pytest.FixtureRequest) -> Path:
+    """Create a test file with custom timeout baseline.
+
+    Params:
+        size: Test size marker (small, medium, large, xlarge)
+        timeout: Custom timeout in seconds
+    """
+    params = request.param
+    size = params['size']
+    timeout = params['timeout']
+
+    return pytester.makepyfile(
+        test_baseline=f"""
+        import pytest
+
+        @pytest.mark.{size}(timeout={timeout})
+        def test_with_baseline():
+            assert True
+        """
+    )
+
+
+@pytest.fixture
+def no_baseline_test_file(pytester: pytest.Pytester, request: pytest.FixtureRequest) -> Path:
+    """Create a test file without custom timeout baseline.
+
+    Params:
+        size: Test size marker (small, medium, large, xlarge)
+    """
+    size = request.param
+    return pytester.makepyfile(
+        test_no_baseline=f"""
+        import pytest
+
+        @pytest.mark.{size}
+        def test_without_baseline():
+            assert True
+        """
+    )
+
+
+@pytest.mark.medium
+class DescribePerformanceBaselineIntegration:
+    """Integration tests for performance baseline feature."""
+
+    @pytest.mark.parametrize(
+        'baseline_test_file',
+        [
+            pytest.param({'size': 'small', 'timeout': 0.1}, id='small-with-100ms-baseline'),
+            pytest.param({'size': 'medium', 'timeout': 5.0}, id='medium-with-5s-baseline'),
+        ],
+        indirect=True,
+    )
+    def it_accepts_timeout_parameter_in_marker(
+        self,
+        pytester: pytest.Pytester,
+        baseline_test_file: Path,
+    ) -> None:
+        """Accept timeout parameter in size marker without error."""
+        result = pytester.runpytest('-v', baseline_test_file)
+        # Test should pass (no syntax error from timeout parameter)
+        result.assert_outcomes(passed=1)
+
+    @pytest.mark.parametrize(
+        'no_baseline_test_file',
+        [
+            pytest.param('small', id='small-without-baseline'),
+            pytest.param('medium', id='medium-without-baseline'),
+        ],
+        indirect=True,
+    )
+    def it_works_without_timeout_parameter(
+        self,
+        pytester: pytest.Pytester,
+        no_baseline_test_file: Path,
+    ) -> None:
+        """Work correctly when no timeout parameter is specified."""
+        result = pytester.runpytest('-v', no_baseline_test_file)
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.medium
+class DescribePerformanceBaselineViolation:
+    """Test baseline violations are reported correctly."""
+
+    def it_reports_baseline_violation_for_slow_test(
+        self,
+        pytester: pytest.Pytester,
+    ) -> None:
+        """Report PerformanceBaselineViolationError when test exceeds baseline."""
+        # Create a test that uses time.sleep to exceed the baseline
+        pytester.makepyfile(
+            test_slow="""
+            import time
+            import pytest
+
+            @pytest.mark.small(timeout=0.01)
+            def test_exceeds_baseline():
+                time.sleep(0.05)  # Sleep 50ms, exceeds 10ms baseline
+                assert True
+            """
+        )
+
+        result = pytester.runpytest('-v')
+        # Test should fail due to baseline violation
+        result.assert_outcomes(failed=1)
+        # Check for performance baseline error message
+        result.stdout.fnmatch_lines(['*Performance Baseline*'])
+
+    def it_passes_when_test_completes_within_baseline(
+        self,
+        pytester: pytest.Pytester,
+    ) -> None:
+        """Pass when test completes within custom baseline."""
+        pytester.makepyfile(
+            test_fast="""
+            import pytest
+
+            @pytest.mark.small(timeout=1.0)
+            def test_within_baseline():
+                # Very fast test, well within 1s baseline
+                assert True
+            """
+        )
+
+        result = pytester.runpytest('-v')
+        result.assert_outcomes(passed=1)
+
+    def it_shows_both_baseline_and_category_limit_in_error(
+        self,
+        pytester: pytest.Pytester,
+    ) -> None:
+        """Include both baseline and category limit in error message."""
+        pytester.makepyfile(
+            test_baseline_error="""
+            import time
+            import pytest
+
+            @pytest.mark.small(timeout=0.01)
+            def test_shows_limits():
+                time.sleep(0.05)
+                assert True
+            """
+        )
+
+        result = pytester.runpytest('-v')
+        result.assert_outcomes(failed=1)
+        # Error should mention both the baseline (0.01s) and category limit (1.0s)
+        output = result.stdout.str()
+        assert '0.0' in output  # baseline (0.01)
+        assert '1.0' in output  # category limit
+
+
+@pytest.mark.medium
+class DescribeBaselineValidation:
+    """Test baseline validation rules."""
+
+    def it_rejects_baseline_exceeding_category_limit(
+        self,
+        pytester: pytest.Pytester,
+    ) -> None:
+        """Reject baseline that exceeds category limit."""
+        pytester.makepyfile(
+            test_invalid_baseline="""
+            import pytest
+
+            @pytest.mark.small(timeout=2.0)  # Exceeds 1.0s SMALL limit
+            def test_invalid():
+                assert True
+            """
+        )
+
+        result = pytester.runpytest('-v')
+        # Test should fail due to invalid baseline configuration
+        result.assert_outcomes(failed=1)
+        result.stdout.fnmatch_lines(['*baseline*category limit*'])

--- a/tests/test_performance_baseline_module.py
+++ b/tests/test_performance_baseline_module.py
@@ -1,0 +1,287 @@
+"""Unit tests for performance baseline validation.
+
+This module tests the performance baseline feature which allows tests to define
+custom timeout limits stricter than their category's default limit.
+
+Example usage:
+    @pytest.mark.small(timeout=0.1)  # Must complete in 100ms instead of 1s
+    def test_critical_path():
+        pass
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pytest_test_categories.types import TestSize
+
+
+@pytest.mark.small
+class DescribePerformanceBaselineViolationError:
+    """Test PerformanceBaselineViolationError exception."""
+
+    def it_can_be_imported_from_timing_module(self) -> None:
+        """Import PerformanceBaselineViolationError from timing module."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        assert PerformanceBaselineViolationError is not None
+
+    def it_stores_test_size(self) -> None:
+        """Store test size in error attributes."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        assert error.test_size == TestSize.SMALL
+
+    def it_stores_test_nodeid(self) -> None:
+        """Store test nodeid in error attributes."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        assert error.test_nodeid == 'tests/test_slow.py::test_compute'
+
+    def it_stores_baseline_limit(self) -> None:
+        """Store custom baseline limit in error attributes."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        assert error.baseline_limit == 0.1
+
+    def it_stores_category_limit(self) -> None:
+        """Store category limit in error attributes."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        assert error.category_limit == 1.0
+
+    def it_stores_actual_duration(self) -> None:
+        """Store actual duration in error attributes."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        assert error.actual == 0.25
+
+    def it_includes_baseline_in_error_message(self) -> None:
+        """Include custom baseline limit in error message."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        message = str(error)
+        assert '0.1' in message
+
+    def it_includes_category_limit_in_error_message(self) -> None:
+        """Include category limit in error message for context."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        message = str(error)
+        assert '1.0' in message
+
+    def it_includes_actual_duration_in_error_message(self) -> None:
+        """Include actual duration in error message."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        message = str(error)
+        assert '0.2' in message  # 0.25 formatted
+
+    def it_includes_test_nodeid_in_error_message(self) -> None:
+        """Include test nodeid in error message."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        message = str(error)
+        assert 'tests/test_slow.py::test_compute' in message
+
+    def it_is_distinct_from_timing_violation_error(self) -> None:
+        """PerformanceBaselineViolationError is not TimingViolationError."""
+        from pytest_test_categories.timing import (
+            PerformanceBaselineViolationError,
+            TimingViolationError,
+        )
+
+        # Verify they are different classes
+        assert PerformanceBaselineViolationError.__name__ != TimingViolationError.__name__
+        assert not issubclass(PerformanceBaselineViolationError, TimingViolationError)
+
+    def it_includes_performance_baseline_in_title(self) -> None:
+        """Include 'Performance Baseline' in error title."""
+        from pytest_test_categories.timing import PerformanceBaselineViolationError
+
+        error = PerformanceBaselineViolationError(
+            test_size=TestSize.SMALL,
+            test_nodeid='tests/test_slow.py::test_compute',
+            baseline_limit=0.1,
+            category_limit=1.0,
+            actual=0.25,
+        )
+
+        message = str(error)
+        assert 'Performance Baseline' in message
+
+
+@pytest.mark.small
+class DescribeValidateWithBaseline:
+    """Test validate function with custom baseline."""
+
+    def it_passes_when_duration_is_within_baseline(self) -> None:
+        """Pass validation when duration is within custom baseline."""
+        from pytest_test_categories.timing import validate_with_baseline
+
+        # Should not raise any exception
+        validate_with_baseline(
+            size=TestSize.SMALL,
+            duration=0.05,
+            baseline=0.1,
+            test_nodeid='test.py::test_func',
+        )
+
+    def it_raises_baseline_violation_when_exceeding_baseline(self) -> None:
+        """Raise PerformanceBaselineViolationError when exceeding baseline."""
+        from pytest_test_categories.timing import (
+            PerformanceBaselineViolationError,
+            validate_with_baseline,
+        )
+
+        with pytest.raises(PerformanceBaselineViolationError):
+            validate_with_baseline(
+                size=TestSize.SMALL,
+                duration=0.15,  # Exceeds 0.1 baseline
+                baseline=0.1,
+                test_nodeid='test.py::test_func',
+            )
+
+    def it_uses_category_limit_when_no_baseline_provided(self) -> None:
+        """Fall back to category limit when baseline is None."""
+        from pytest_test_categories.timing import (
+            TimingViolationError,
+            validate_with_baseline,
+        )
+
+        with pytest.raises(TimingViolationError):
+            validate_with_baseline(
+                size=TestSize.SMALL,
+                duration=1.5,  # Exceeds 1.0 category limit
+                baseline=None,
+                test_nodeid='test.py::test_func',
+            )
+
+    def it_passes_when_within_category_limit_without_baseline(self) -> None:
+        """Pass when duration is within category limit and no baseline."""
+        from pytest_test_categories.timing import validate_with_baseline
+
+        # Should not raise any exception
+        validate_with_baseline(
+            size=TestSize.SMALL,
+            duration=0.5,  # Within 1.0 category limit
+            baseline=None,
+            test_nodeid='test.py::test_func',
+        )
+
+    def it_includes_category_limit_in_baseline_error(self) -> None:
+        """Include category limit for context in baseline error."""
+        from pytest_test_categories.timing import (
+            PerformanceBaselineViolationError,
+            validate_with_baseline,
+        )
+
+        with pytest.raises(PerformanceBaselineViolationError) as exc_info:
+            validate_with_baseline(
+                size=TestSize.SMALL,
+                duration=0.15,
+                baseline=0.1,
+                test_nodeid='test.py::test_func',
+            )
+
+        # Category limit (1.0s for SMALL) should be in message
+        assert '1.0' in str(exc_info.value)
+
+    def it_works_with_medium_test_size(self) -> None:
+        """Handle medium test size correctly."""
+        from pytest_test_categories.timing import (
+            PerformanceBaselineViolationError,
+            validate_with_baseline,
+        )
+
+        with pytest.raises(PerformanceBaselineViolationError):
+            validate_with_baseline(
+                size=TestSize.MEDIUM,
+                duration=10.0,  # Exceeds 5.0 baseline
+                baseline=5.0,
+                test_nodeid='test.py::test_func',
+            )
+
+    def it_validates_baseline_is_less_than_or_equal_to_category_limit(self) -> None:
+        """Validate that baseline does not exceed category limit."""
+        from pytest_test_categories.timing import validate_with_baseline
+
+        with pytest.raises(ValueError, match=r'baseline.*category limit'):
+            validate_with_baseline(
+                size=TestSize.SMALL,
+                duration=0.5,
+                baseline=2.0,  # Exceeds 1.0 category limit
+                test_nodeid='test.py::test_func',
+            )

--- a/tests/test_plugin_module.py
+++ b/tests/test_plugin_module.py
@@ -440,6 +440,7 @@ class DescribePytestRuntestMakereport:
 
         mock_discovery_service = Mock(spec=TestDiscoveryService)
         mock_discovery_service.find_test_size.return_value = TestSize.SMALL
+        mock_discovery_service.get_timeout.return_value = None  # No custom baseline
         item.config._test_categories_state.test_discovery_service = mock_discovery_service
 
         gen = pytest_runtest_makereport(item)
@@ -482,6 +483,7 @@ class DescribePytestRuntestMakereport:
 
         mock_discovery_service = Mock(spec=TestDiscoveryService)
         mock_discovery_service.find_test_size.return_value = TestSize.SMALL
+        mock_discovery_service.get_timeout.return_value = None  # No custom baseline
         item.config._test_categories_state.test_discovery_service = mock_discovery_service
 
         gen = pytest_runtest_makereport(item)


### PR DESCRIPTION
## Summary

This PR implements per-test performance baselines as described in Issue #162. Tests can now define custom timeout limits stricter than their category's default time limit:

```python
@pytest.mark.small(timeout=0.1)  # Must complete in 100ms instead of 1s
def test_critical_path():
    pass
```

- Add `PerformanceBaselineViolationError` exception (distinct from `TimingViolationError`)
- Error messages show both the custom baseline AND the category limit for context
- JSON reports track baseline violations separately from timing violations
- Baseline must be <= category limit (validated at runtime)

## Changes

### Core Implementation
- **timing.py**: New `PerformanceBaselineViolationError` and `validate_with_baseline()` function
- **errors.py**: Added TC008 error code for performance baseline violations
- **test_discovery.py**: Added `get_timeout()` method to extract timeout from marker kwargs
- **timing_validation.py**: Added `validate_timing_with_baseline()` method
- **plugin.py**: Updated `pytest_runtest_makereport` to use baseline validation
- **reporting.py**: Added `BaselineViolation` model and tracking methods
- **json_report.py**: Added `baseline` field to `ViolationsSummary`, refactored for complexity

### Tests
- **test_performance_baseline_module.py**: 19 unit tests for error and validation
- **test_performance_baseline_feature.py**: 8 integration tests with pytester
- Updated existing test files for new functionality

### Documentation
- Updated README with Performance Baselines section
- Updated JSON report structure example
- Updated CHANGELOG for v1.2.0

## Test Plan

- [x] All 77 new/modified tests pass
- [x] Pre-commit hooks pass (isort, ruff, mypy, tox)
- [x] 100% code coverage maintained
- [x] Integration tests verify end-to-end behavior with pytester
- [x] Documentation updated in same commit

Fixes #162